### PR TITLE
Pass 'allow_pickle=True' to numpy.load (default changed in np 1.16.3)

### DIFF
--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -154,7 +154,7 @@ class GaussianProcess(object):
                 a float (if no theta values are found in the emulator file)
         """
         
-        emulator_file = np.load(filename)
+        emulator_file = np.load(filename, allow_pickle=True)
         
         try:
             inputs = np.array(emulator_file['inputs'])
@@ -693,4 +693,3 @@ class GaussianProcess(object):
         """
         
         return "Gaussian Process with "+str(self.n)+" training examples and "+str(self.D)+" input variables"
-        

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -169,7 +169,7 @@ class MultiOutputGP(object):
                 are found in the emulator file)
         """
 
-        emulator_file = np.load(filename)
+        emulator_file = np.load(filename, allow_pickle=True)
         
         try:
             inputs = np.array(emulator_file['inputs'])

--- a/mogp_emulator/SequentialDesign.py
+++ b/mogp_emulator/SequentialDesign.py
@@ -149,7 +149,7 @@ class SequentialDesign(object):
         :returns: None
         """
         
-        design_file = np.load(filename)
+        design_file = np.load(filename, allow_pickle=True)
         
         self.inputs = np.array(design_file['inputs'])
         if np.all(self.inputs) == None:

--- a/mogp_emulator/tests/test_GaussianProcess.py
+++ b/mogp_emulator/tests/test_GaussianProcess.py
@@ -128,7 +128,7 @@ def test_GaussianProcess_save_emulators():
     with TemporaryFile() as tmp:
         gp.save_emulator(tmp)
         tmp.seek(0)
-        emulator_file = np.load(tmp)
+        emulator_file = np.load(tmp, allow_pickle=True)
         assert_allclose(emulator_file['inputs'], x)
         assert_allclose(emulator_file['targets'], y)
         assert emulator_file['nugget'] == None
@@ -144,7 +144,7 @@ def test_GaussianProcess_save_emulators():
     with TemporaryFile() as tmp:
         gp.save_emulator(tmp)
         tmp.seek(0)
-        emulator_file = np.load(tmp)
+        emulator_file = np.load(tmp, allow_pickle=True)
         assert_allclose(emulator_file['inputs'], x)
         assert_allclose(emulator_file['targets'], y)
         assert_allclose(emulator_file['theta'], theta)

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -115,7 +115,7 @@ def test_MultiOutputGP_save_emulators():
     with TemporaryFile() as tmp:
         gp.save_emulators(tmp)
         tmp.seek(0)
-        emulator_file = np.load(tmp)
+        emulator_file = np.load(tmp, allow_pickle=True)
         assert_allclose(emulator_file['inputs'], x)
         assert_allclose(emulator_file['targets'], y)
         assert emulator_file['nugget'][0] == None
@@ -133,7 +133,7 @@ def test_MultiOutputGP_save_emulators():
     with TemporaryFile() as tmp:
         gp.save_emulators(tmp)
         tmp.seek(0)
-        emulator_file = np.load(tmp)
+        emulator_file = np.load(tmp, allow_pickle=True)
         assert_allclose(emulator_file['inputs'], x)
         assert_allclose(emulator_file['targets'], y)
         assert_allclose(np.array(emulator_file['nugget'], dtype=float), 1.e-6)


### PR DESCRIPTION
Fixes some failing tests with numpy 1.17.1.  Loading GaussianProcess, SequentialDesign and MultiOutputGP requires loading pickled objects with np.load, which is disallowed by default since numpy 1.16.3.