### PR TITLE
Feature/formula

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "3.6"
+  - "3.7"
 install:
   - pip install -r requirements.txt
-  - pip install pytest-cov codecov
+  - pip install pytest-cov codecov patsy
   - python setup.py install
 script:
   - pytest --cov=./

--- a/docs/MeanFunction.rst
+++ b/docs/MeanFunction.rst
@@ -1,0 +1,36 @@
+.. _MeanFunction:
+
+**********************************
+The ``MeanFunction`` Module
+**********************************
+
+.. automodule:: mogp_emulator.MeanFunction
+    :noindex:
+
+.. autoclass:: mogp_emulator.MeanFunction.MeanFunction
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.MeanSum
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.MeanProduct
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.MeanComposite
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.FixedMean
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.ConstantMean
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.LinearMean
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.Coefficient
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.PolynomialMean
+    :members:
+

--- a/docs/MeanFunction.rst
+++ b/docs/MeanFunction.rst
@@ -5,15 +5,19 @@ The ``MeanFunction`` Module
 **********************************
 
 .. automodule:: mogp_emulator.MeanFunction
+    :members: MeanFunction
     :noindex:
 
-.. autoclass:: mogp_emulator.MeanFunction.MeanFunction
+.. autoclass:: mogp_emulator.MeanFunction.MeanBase
     :members:
 
 .. autoclass:: mogp_emulator.MeanFunction.MeanSum
     :members:
 
 .. autoclass:: mogp_emulator.MeanFunction.MeanProduct
+    :members:
+
+.. autoclass:: mogp_emulator.MeanFunction.MeanPower
     :members:
 
 .. autoclass:: mogp_emulator.MeanFunction.MeanComposite

--- a/docs/formula.rst
+++ b/docs/formula.rst
@@ -1,0 +1,9 @@
+.. _formula:
+
+**********************************
+The ``formula`` Module
+**********************************
+
+.. automodule:: mogp_emulator.formula
+    :members:
+    :noindex:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to Multi-Output GP Emulator's documentation!
    DimensionReduction
    MultiOutputGP
    MeanFunction
+   formula
    Kernel
    ExperimentalDesign
    SequentialDesign

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to Multi-Output GP Emulator's documentation!
    GaussianProcess
    DimensionReduction
    MultiOutputGP
+   MeanFunction
    Kernel
    ExperimentalDesign
    SequentialDesign

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -1270,16 +1270,68 @@ class Coefficient(MeanFunction):
         return np.zeros((x.shape[1], x.shape[0]))
 
 class PolynomialMean(MeanFunction):
-    "mean function where every input dimension is fit to a fixed degree polynomial"
+    """
+    Polynomial mean function class
+
+    A ``PolynomialMean`` is a mean function where every input dimension is fit to a fixed
+    degree polynomial. The degree must be provided when creating the class instance. The
+    number of parameters depends on the degree and the shape of the inputs, since a separate
+    set of parameters are used for each input dimension.
+
+    :iparam degree: Polynomial degree, must be a positive integer
+    :type degree: int
+    """
     def __init__(self, degree):
-        assert int(degree) >= 0., "degree must be a positive integer"
+        """
+        Create a new polynomial mean function instance
+
+        A ``PolynomialMean`` is a mean function where every input dimension is fit to a fixed
+        degree polynomial. The degree must be provided when creating the class instance. The
+        number of parameters depends on the degree and the shape of the inputs, since a separate
+        set of parameters are used for each input dimension. Must provide the degree when
+        initializing.
+
+        :param degree: Polynomial degree, must be a positive integer
+        :type degree: int
+        :returns: new ``PolynomialMean`` instance
+        :rtype: PolynomialMean
+        """
+        assert int(degree) > 0, "degree must be a positive integer"
 
         self.degree = int(degree)
 
     def get_n_params(self, x):
+        """
+        Determine the number of parameters
+
+        Returns the number of parameters for the mean function, which depends on x.
+
+        :param x: Input array
+        :type x: ndarray
+        :returns: number of parameters
+        :rtype: int
+        """
         return x.shape[1]*self.degree + 1
 
     def mean_f(self, x, params):
+        """
+        Returns value of mean function
+
+        Method to compute the value of the mean function for the inputs and parameters provided.
+        Shapes of ``x`` and ``params`` must be consistent based on the return value of the
+        ``get_n_params`` method. Returns a numpy array of shape ``(x.shape[0],)`` holding
+        the value of the mean function for each input point.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function evaluated at all input points, numpy array of shape
+                  ``(x.shape[0],)``
+        :rtype: ndarray
+        """
         x, params = self._check_inputs(x, params)
 
         n_params = self.get_n_params(x)
@@ -1292,6 +1344,26 @@ class PolynomialMean(MeanFunction):
         return output
 
     def mean_deriv(self, x, params):
+        """
+        Returns value of mean function derivative wrt the parameters
+
+        Method to compute the value of the mean function derivative with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, x.shape[0])`` holding the value of the mean
+        function derivative with respect to each parameter (first axis) for each input point
+        (second axis).
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
@@ -1308,6 +1380,27 @@ class PolynomialMean(MeanFunction):
         return deriv
 
     def mean_hessian(self, x, params):
+        """
+        Returns value of mean function Hessian wrt the parameters
+
+        Method to compute the value of the mean function Hessian with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, n_params, x.shape[0])`` holding the
+        value of the mean function second derivaties with respect to each parameter pair
+        (first twp axes) for each input point (last axis). Since polynomial means depend
+        linearly on all input parameters, this will always be an array of zeros.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function Hessian with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_parmas, n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
@@ -1318,6 +1411,27 @@ class PolynomialMean(MeanFunction):
         return hess
 
     def mean_inputderiv(self, x, params):
+        """
+        Returns value of mean function derivative wrt the inputs
+
+        Method to compute the value of the mean function derivative with respect to the
+        inputs for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(x.shape[1], x.shape[0])`` holding the value of the mean
+        function derivative with respect to each input (first axis) for each input point
+        (second axis).
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the inputs evaluated
+                  at all input points, numpy array of shape ``(x.shape[1], x.shape[0])``
+        :rtype: ndarray
+        """
+
         x, params = self._check_inputs(x, params)
 
         expon = np.reshape(np.arange(0, x.shape[0]*x.shape[1]*self.degree)//x.shape[1]//self.degree,

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -1,0 +1,312 @@
+import numpy as np
+from functools import partial
+
+class MeanFunction(object):
+    def _check_inputs(self, x, params):
+        "check the shape of the inputs"
+
+        if len(x.shape) == 1:
+            x = np.reshape(x, (-1, 1))
+        assert len(x.shape) == 2, "inputs must be a 1D or 2D array"
+
+        assert len(params.shape) == 1, "params must be a 1D array"
+
+        assert len(params) == self.get_n_params(x), "bad length for params"
+
+        return x, params
+
+    def get_n_params(self, x):
+        "determine the number of parameters, possibly which is dependent on x"
+
+        raise NotImplementedError("base mean function does not implement a particular function")
+
+    def mean_f(self, x, params):
+        "returns value of mean function"
+
+        raise NotImplementedError("base mean function does not implement a particular function")
+
+    def mean_deriv(self, x, params):
+        "returns derivative of mean function wrt params"
+
+        raise NotImplementedError("base mean function does not implement a particular function")
+
+    def mean_hessian(self, x, params):
+        "returns hessian of mean function wrt params"
+
+        raise NotImplementedError("base mean function does not implement a particular function")
+
+    def mean_inputderiv(self, x, params):
+        "returns derivative of mean function wrt inputs"
+
+        raise NotImplementedError("base mean function does not implement a particular function")
+
+    def __add__(self, other):
+        "combines two mean functions"
+
+        if issubclass(type(other), MeanFunction):
+            return MeanSum(self, other)
+        elif isinstance(other, (float, int)):
+            return MeanSum(self, FixedMean(other))
+        else:
+            raise TypeError("other function cannot be added with a MeanFunction")
+
+    def __radd__(self, other):
+        "combines two mean functions"
+
+        if issubclass(type(other), MeanFunction):
+            return MeanSum(other, self)
+        elif isinstance(other, (float, int)):
+            return MeanSum(FixedMean(other), self)
+        else:
+            raise TypeError("other function cannot be added with a MeanFunction")
+
+    def __mul__(self, other):
+        "multiplies two mean functions"
+
+        if issubclass(type(other), MeanFunction):
+            return MeanProduct(self, other)
+        elif isinstance(other, (float, int)):
+            return MeanProduct(self, FixedMean(other))
+        else:
+            raise TypeError("other function cannot be added with a MeanFunction")
+
+    def __rmul__(self, other):
+        "multiplies two mean functions"
+
+        if issubclass(type(other), MeanFunction):
+            return MeanProduct(other, self)
+        elif isinstance(other, (float, int)):
+            return MeanProduct(FixedMean(other), self)
+        else:
+            raise TypeError("other function cannot be added with a MeanFunction")
+
+class MeanSum(MeanFunction):
+    def __init__(self, f1, f2):
+
+        if not issubclass(type(f1), MeanFunction):
+            raise TypeError("inputs to MeanSum must be subclasses of MeanFunction")
+        if not issubclass(type(f2), MeanFunction):
+            raise TypeError("inputs to MeanSum must be subclasses of MeanFunction")
+
+        self.f1 = f1
+        self.f2 = f2
+
+    def get_n_params(self, x):
+        return self.f1.get_n_params(x) + self.f2.get_n_params(x)
+
+    def mean_f(self, x, params):
+        "returns value of mean function"
+
+        switch = self.f1.get_n_params(x)
+
+        return (self.f1.mean_f(x, params[:switch]) +
+                self.f2.mean_f(x, params[switch:]))
+
+    def mean_deriv(self, x, params):
+        "returns derivative of mean function wrt params"
+
+        switch = self.f1.get_n_params(x)
+
+        deriv = np.zeros((self.get_n_params(x), x.shape[0]))
+
+        deriv[:switch] = self.f1.mean_deriv(x, params[:switch])
+        deriv[switch:] = self.f2.mean_deriv(x, params[switch:])
+
+        return deriv
+
+    def mean_hessian(self, x, params):
+        "returns hessian of mean function wrt params"
+
+        switch = self.f1.get_n_params(x)
+
+        hess = np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
+
+        hess[:switch, :switch] = self.f1.mean_hessian(x, params[:switch])
+        hess[switch:, switch:] = self.f2.mean_hessian(x, params[switch:])
+
+        return hess
+
+    def mean_inputderiv(self, x, params):
+        "returns derivative of mean function wrt inputs"
+
+        switch = self.f1.get_n_params(x)
+
+        return (self.f1.mean_inputderiv(x, params[:switch]) +
+                self.f2.mean_inputderiv(x, params[switch:]))
+
+class MeanProduct(MeanFunction):
+    def __init__(self, f1, f2):
+
+        if not issubclass(type(f1), MeanFunction):
+            raise TypeError("inputs to MeanProduct must be subclasses of MeanFunction")
+        if not issubclass(type(f2), MeanFunction):
+            raise TypeError("inputs to MeanProduct must be subclasses of MeanFunction")
+
+        self.f1 = f1
+        self.f2 = f2
+
+    def get_n_params(self, x):
+        return self.f1.get_n_params(x) + self.f2.get_n_params(x)
+
+    def mean_f(self, x, params):
+        "returns value of mean function"
+
+        switch = self.f1.get_n_params(x)
+
+        return (self.f1.mean_f(x, params[:switch])*
+                self.f2.mean_f(x, params[switch:]))
+
+    def mean_deriv(self, x, params):
+        "returns derivative of mean function wrt params"
+
+        switch = self.f1.get_n_params(x)
+
+        deriv = np.zeros((self.get_n_params(x), x.shape[0]))
+
+        deriv[:switch] = (self.f1.mean_deriv(x, params[:switch])*
+                          self.f2.mean_f(x, params[switch:]))
+
+        deriv[switch:] = (self.f1.mean_f(x, params[:switch])*
+                          self.f2.mean_deriv(x, params[switch:]))
+
+        return deriv
+
+    def mean_hessian(self, x, params):
+        "returns hessian of mean function wrt params"
+
+        switch = self.f1.get_n_params(x)
+
+        hess = np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
+
+        hess[:switch, :switch] = (self.f1.mean_hessian(x, params[:switch])*
+                                  self.f2.mean_f(x, params[switch:]))
+        hess[:switch, switch:, :] = (self.f1.mean_deriv(x, params[:switch])[:,np.newaxis,:]*
+                                     self.f2.mean_deriv(x, params[switch:])[np.newaxis,:,:])
+        hess[switch:, :switch, :] = np.transpose(hess[:switch, switch:, :], (1, 0, 2))
+        hess[switch:, switch:] = (self.f1.mean_f(x, params[:switch])*
+                                  self.f2.mean_hessian(x, params[switch:]))
+
+        return hess
+
+
+    def mean_inputderiv(self, x, params):
+        "returns derivative of mean function wrt inputs"
+
+        switch = self.f1.get_n_params(x)
+
+        return (self.f1.mean_inputderiv(x, params[:switch])*
+                self.f2.mean_f(x, params[switch:]) +
+                self.f1.mean_f(x, params[:switch])*
+                self.f2.mean_inputderiv(x, params[switch:]))
+
+class FixedMean(MeanFunction):
+    "a mean function with a fixed function/derivative and no fitting parameters"
+    def __init__(self, *args):
+
+        if len(args) == 1 and isinstance(args[0], (float, int)):
+            val = float(args[0])
+            def f_full(x, val):
+                return np.broadcast_to(val, x.shape[0])
+            f = partial(f_full, val=val)
+            deriv = lambda x: np.zeros((x.shape[1], x.shape[0]))
+        elif len(args) == 1 or len(args) == 2:
+            f = args[0]
+            if len(args) == 1:
+                deriv = None
+            else:
+                deriv = args[1]
+        else:
+            raise ValueError("Bad length of arguments provided to FixedMean")
+
+        assert callable(f), "fixed mean function must be a callable function"
+        if not deriv is None:
+            assert callable(deriv), "mean function derivative must be a callable function"
+
+        self.f = f
+        self.deriv = deriv
+
+    def get_n_params(self, x):
+        return 0
+
+    def mean_f(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return self.f(x)
+
+    def mean_deriv(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.zeros((self.get_n_params(x), x.shape[0]))
+
+    def mean_hessian(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
+
+    def mean_inputderiv(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        if self.deriv is None:
+            raise NotImplementedError("Derivative function was not provided with this FixedMean")
+        else:
+            return self.deriv(x)
+
+class ConstantMean(MeanFunction):
+    def get_n_params(self, x):
+        return 1
+
+    def mean_f(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.broadcast_to([params[0]], x.shape[0])
+
+    def mean_deriv(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.ones((self.get_n_params(x), x.shape[0]))
+
+    def mean_hessian(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
+
+    def mean_inputderiv(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.zeros((x.shape[1], x.shape[0]))
+
+class LinearMean(MeanFunction):
+    def get_n_params(self, x):
+        return x.shape[1]
+
+    def mean_f(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.sum(params*x, axis=1)
+
+    def mean_deriv(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.transpose(x)
+
+    def mean_hessian(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
+
+    def mean_inputderiv(self, x, params):
+
+        x, params = self._check_inputs(x, params)
+
+        return np.broadcast_to(np.reshape(params, (-1, 1)), (x.shape[1], x.shape[0]))

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -208,7 +208,8 @@ class FixedMean(MeanFunction):
             def f_full(x, val):
                 return np.broadcast_to(val, x.shape[0])
             f = partial(f_full, val=val)
-            deriv = lambda x: np.zeros((x.shape[1], x.shape[0]))
+            def deriv(x):
+                return np.zeros((x.shape[1], x.shape[0]))
         elif len(args) == 1 or len(args) == 2:
             f = args[0]
             if len(args) == 1:

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -65,8 +65,8 @@ class MeanFunction(object):
     attributes that must be set and so are likely to need a ``__init__`` method.
     """
 
-    @classmethod
-    def from_formula(cls, formula, inputdict={}, use_patsy=True):
+    @staticmethod
+    def from_formula(formula, inputdict={}, use_patsy=True):
         """
         Create a mean function from a formula
         """
@@ -74,15 +74,13 @@ class MeanFunction(object):
         if formula is None or (isinstance(formula, str) and formula.strip() == ""):
             return ConstantMean(0.)
 
+        if not isinstance(formula, str):
+            raise ValueError("input formula must be a string")
+
         if use_patsy:
             mf = mean_from_patsy_formula(formula, inputdict)
         else:
-            if not isinstance(formula, str):
-                raise ValueError("input formula must be a string")
-            mf = code_to_mean(formula, inputdict)
-
-        assert issubclass(type(mf), cls), ("error in from_formula class method: result did not " +
-                                           "produce the desired class")
+            mf = mean_from_string(formula, inputdict)
 
         return mf
 

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -852,17 +852,19 @@ class MeanPower(MeanFunction):
         switch = self.f1.get_n_params(x)
 
         exp = self.f2.mean_f(x, params[switch:])
+        nonzeroexp = True
         if np.allclose(exp, 0.):
-            exp = 0
+            nonzeroexp = False
 
         deriv = np.zeros((self.get_n_params(x), x.shape[0]))
 
-        if not exp == 0:
-            deriv[:switch] = (exp*self.f1.mean(x, params[:switch])**(exp - 1.)*
+        if nonzeroexp:
+            deriv[:switch] = (exp*self.f1.mean_f(x, params[:switch])**(exp - 1.)*
                               self.f1.mean_deriv(x, params[:switch]))
 
-            deriv[switch:] = (exp*self.f1.mean(x, params[:switch])**(exp - 1.)*
-                              self.f2.mean_deriv(x, params[:switch]))
+        deriv[switch:] = (np.log(self.f1.mean_f(x, params[:switch]))*
+                          self.f1.mean_f(x, params[:switch])**exp*
+                          self.f2.mean_deriv(x, params[switch:]))
 
         return deriv
 
@@ -894,25 +896,27 @@ class MeanPower(MeanFunction):
         switch = self.f1.get_n_params(x)
 
         exp = self.f2.mean_f(x, params[switch:])
+        nonzeroexp = True
         if np.allclose(exp, 0.):
-            exp = 0
+            nonzeroexp = False
+        nononeexp = True
         if np.allclose(exp, 1.):
-            exp = 1
+            nononeexp = False
 
         hess = np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
 
-        if (not exp == 0) or (not exp == 1):
+        if nonzeroexp or nononeexp:
 
             hess[:switch, :switch] = (exp*(exp - 1)*self.f1.mean_f(x, params[:switch])**(exp - 2.)*
-                                      self.f1.mean_hessian(x, params[switch:]))
+                                      self.f1.mean_hessian(x, params[:switch]))
 
-        if not (exp == 0):
+        if nonzeroexp:
             hess[:switch, switch:, :] = (exp*(exp - 1)*self.f1.mean_f(x, params[:switch])**(exp - 2.)*
                                          self.f1.mean_deriv(x, params[:switch])[:,np.newaxis,:]*
                                          self.f2.mean_deriv(x, params[switch:])[np.newaxis,:,:])
             hess[switch:, :switch, :] = np.transpose(hess[:switch, switch:, :], (1, 0, 2))
 
-        if (not exp == 0) or (not exp == 1):
+        if nonzeroexp or nononeexp:
             hess[switch:, switch:] = (exp*(exp - 1)*self.f1.mean_f(x, params[:switch])**(exp - 2.)*
                                       self.f2.mean_hessian(x, params[switch:]))
 
@@ -947,12 +951,13 @@ class MeanPower(MeanFunction):
         switch = self.f1.get_n_params(x)
 
         exp = self.f2.mean_f(x, params[switch:])
+        nonzeroexp = True
         if np.allclose(exp, 0.):
-            exp = 0
+            nonzeroexp = False
 
         inputderiv = np.zeros((x.shape[1], x.shape[0]))
 
-        if not exp == 0:
+        if nonzeroexp:
             inputderiv = (exp*self.f1.mean_f(x, params[:switch])**(exp - 1.)*
                           self.f1.mean_inputderiv(x, params[:switch]))
 

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -108,14 +108,40 @@ def MeanFunction(formula, inputdict={}, use_patsy=True):
     take care that the provided expression is sensible as a mean function and will not
     cause problems when fitting.
 
+    Additional special cases to be aware of:
+
+    * ``call`` cannot be used as a variable name, if this is parsed as a token an exception
+      will be raised.
+    * ``I`` is the identity operator, it simply returns the given value. It is useful
+      if you wish to use patsy to evaluate a formula but protect a part of the string
+      formula from being expanded based on the rules in patsy. If ``I`` is encountered
+      in any other context, an exception will be raised.
+
     Examples: ::
 
         >>> from mogp_emulator.MeanFunction import MeanFunction
-        >>> mf1 = MeanFunction("x[0]") # uses patsy to parse this to y = a + b*x[0]
-        >>> mf2 = MeanFunction("y = a + b*x[0]", use_patsy=False) # same as previous
-        >>> mf3 = MeanFunction("a*b", {"a": 0, "b": 1}) # y = c1 + c2*x[0] + c3*x[1] + c4*x[0]*x[1]
+        >>> mf1 = MeanFunction("x[0]")
+        >>> print(mf1)
+        c + c*x[0]
+        >>> mf2 = MeanFunction("y = a + b*x[0]", use_patsy=False)
+        >>> print(mf2)
+        c + c*x[0]
+        >>> mf3 = MeanFunction("a*b", {"a": 0, "b": 1})
+        >>> print(mf3)
+        c + c*x[0] + c*x[1] + c*x[0]*x[1]
 
     :param formula: string representing the desired mean function formula
+    :type formula: str
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :param use_patsy: Boolean flag indicating if the string is to be parsed using
+                      patsy library. Optional, default is ``True``. If patsy is not
+                      installed, the basic string parser will be used.
+    :type use_patsy: bool
+    :returns: New subclass of ``MeanBase`` implementing the given formula
+    :rtype: subclass of MeanBase (exact type will depend on the formula that is provided)
     """
 
     if formula is None or (isinstance(formula, str) and formula.strip() == ""):

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -199,17 +199,20 @@ class MeanProduct(MeanFunction):
                 self.f1.mean_f(x, params[:switch])*
                 self.f2.mean_inputderiv(x, params[switch:]))
 
+def const_f(x, val):
+    return np.broadcast_to(val, x.shape[0])
+
+def zero_inputderiv(x):
+    return np.zeros((x.shape[1], x.shape[0]))
+
 class FixedMean(MeanFunction):
     "a mean function with a fixed function/derivative and no fitting parameters"
     def __init__(self, *args):
 
         if len(args) == 1 and isinstance(args[0], (float, int)):
             val = float(args[0])
-            def f_full(x, val):
-                return np.broadcast_to(val, x.shape[0])
-            f = partial(f_full, val=val)
-            def deriv(x):
-                return np.zeros((x.shape[1], x.shape[0]))
+            f = partial(const_f, val=val)
+            deriv = zero_inputderiv
         elif len(args) == 1 or len(args) == 2:
             f = args[0]
             if len(args) == 1:

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -42,6 +42,7 @@ Example: ::
 """
 import numpy as np
 from functools import partial
+from .formula import mean_from_patsy_formula, mean_from_string
 
 class MeanFunction(object):
     """
@@ -63,6 +64,27 @@ class MeanFunction(object):
     The base class does not have any attributes, but subclasses will usually have some
     attributes that must be set and so are likely to need a ``__init__`` method.
     """
+
+    @classmethod
+    def from_formula(cls, formula, inputdict={}, use_patsy=True):
+        """
+        Create a mean function from a formula
+        """
+
+        if formula is None or (isinstance(formula, str) and formula.strip() == ""):
+            return ConstantMean(0.)
+
+        if use_patsy:
+            mf = mean_from_patsy_formula(formula, inputdict)
+        else:
+            if not isinstance(formula, str):
+                raise ValueError("input formula must be a string")
+            mf = code_to_mean(formula, inputdict)
+
+        assert issubclass(type(mf), cls), ("error in from_formula class method: result did not " +
+                                           "produce the desired class")
+
+        return mf
 
     def _check_inputs(self, x, params):
         """

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -1136,29 +1136,134 @@ class LinearMean(FixedMean):
         self.deriv = partial(fixed_inputderiv, index=index, deriv=one)
 
 class Coefficient(MeanFunction):
-    "class representing a single parameter fitting coefficient"
+    """
+    Class representing a single fitting parameter in a mean function
+
+    Class representing a mean function with single free fitting parameter. Does not require any
+    internal state as the parameter value is stored/set externally through fitting routines.
+    """
     def get_n_params(self, x):
+        """
+        Determine the number of parameters
+
+        Returns the number of parameters for the mean function, which possibly depends on x.
+        For a ``Coefficient`` class, this is always 1.
+
+        :param x: Input array
+        :type x: ndarray
+        :returns: number of parameters
+        :rtype: int
+        """
         return 1
 
     def mean_f(self, x, params):
+        """
+        Returns value of mean function
+
+        Method to compute the value of the mean function for the inputs and parameters provided.
+        Shapes of ``x`` and ``params`` must be consistent based on the return value of the
+        ``get_n_params`` method. For ``Coefficient`` classes, the inputs are ignored and the
+        function returns the value of the parameter broadcasting it appropriately given the
+        shape of the inputs. Thus, the ``params`` argument should always be an array of length
+        one. Returns a numpy array of shape ``(x.shape[0],)`` holding the value of the
+        parameter for each input point.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input (one in this case)
+        :type params: ndarray
+        :returns: Value of mean function evaluated at all input points, numpy array of shape
+                  ``(x.shape[0],)``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
-        return np.broadcast_to([params[0]], x.shape[0])
+        return np.broadcast_to(params, x.shape[0])
 
     def mean_deriv(self, x, params):
+        """
+        Returns value of mean function derivative wrt the parameters
+
+        Method to compute the value of the mean function derivative with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        For ``Coefficient`` classes, the inputs are ignored and the derivative function
+        returns one, broadcasting it appropriately given the shape of the inputs.
+        Returns a numpy array of ones with shape ``(1, x.shape[0])`` holding the value
+        of the mean function derivative with respect to each parameter (first axis) for
+        each input point (second axis). Since coefficients are single parameters, this
+        will just be an array of ones.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
         return np.ones((self.get_n_params(x), x.shape[0]))
 
     def mean_hessian(self, x, params):
+        """
+        Returns value of mean function Hessian wrt the parameters
+
+        Method to compute the value of the mean function Hessian with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        For ``Coefficient`` classes, there is only a single parameter so the ``params``
+        argument should be an array of length one. Returns a numpy array of shape
+        ``(n_params, n_params, x.shape[0])`` holding the value of the mean function
+        second derivaties with respect to each parameter pair (first twp axes) for each
+        input point (last axis). Since coefficients depend linearly on a single parameter,
+        this will always be an array of zeros.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function Hessian with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_parmas, n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
         return np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
 
     def mean_inputderiv(self, x, params):
+        """
+        Returns value of mean function derivative wrt the inputs
+
+        Method to compute the value of the mean function derivative with respect to the
+        inputs for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        For ``Coefficient`` classes, there is a single parameters so the ``params`` argument
+        should be an array of length one. Returns a numpy array of shape
+        ``(x.shape[1], x.shape[0])`` holding the value of the mean function derivative
+        with respect to each input (first axis) for each input point (second axis).
+        Since coefficients do not depend on the inputs, this is just an array of zeros.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the inputs evaluated
+                  at all input points, numpy array of shape ``(x.shape[1], x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -2,10 +2,50 @@ import numpy as np
 from functools import partial
 
 class MeanFunction(object):
-    "base class for mean function, implements sum, product, and composition methods"
+    """
+    Base mean function class
+
+    The base class for the mean function implementation includes code for checking inputs and
+    implements sum, product, and composition methods to allow more complicated functions to be
+    built up from fixed functions and fitting coefficients. Subclasses need to implement the
+    following methods:
+
+    * ``get_n_params`` which returns the number of parameters for a given input size. This is
+      usually a constant, but can be more complicated (such as the provided ``PolynomialMean``
+      class)
+    * ``mean_f`` computes the mean function for the provided inputs and parameters
+    * ``mean_deriv`` computes the derivative with respect to the parameters
+    * ``mean_hessian`` computes the hessian with respect to the parameters
+    * ``mean_inputderiv`` computes the derivate with respect to the inputs
+
+    The base class does not have any attributes, but subclasses will usually have some
+    attributes that must be set and so are likely to need a ``__init__`` method.
+    """
 
     def _check_inputs(self, x, params):
-        "check the shape of the inputs and reshape if needed"
+        """
+        Check the shape of the inputs and reshape if needed
+
+        This method checks that the inputs and parameters are consistent for the provided
+        mean function. In particular, the following must be met:
+
+        * The inputs ``x`` must be a 2D numpy array, though if it is 1D it is reshaped to add
+          a second dimenion of length 1.
+        * ``params`` must be a 1D numpy array. If a multi-dimensional array is provided, it
+          will be flattened.
+        * ``params`` must have a length that is the same as the return value of ``get_n_params``
+          when called with the inputs. Note that some mean functions may have different
+          numbers of parameters depending on the inputs, so this may not be known in advance.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: tuple containing the reshaped ``x`` and ``params`` arrays
+        :rtype: tuple containing two ndarrays
+        """
 
         x = np.array(x)
         params = np.array(params).flatten()
@@ -21,32 +61,127 @@ class MeanFunction(object):
         return x, params
 
     def get_n_params(self, x):
-        "determine the number of parameters, possibly which is dependent on x"
+        """
+        Determine the number of parameters
+
+        Returns the number of parameters for the mean function, which possibly depends on x.
+
+        :param x: Input array
+        :type x: ndarray
+        :returns: number of parameters
+        :rtype: int
+        """
 
         raise NotImplementedError("base mean function does not implement a particular function")
 
     def mean_f(self, x, params):
-        "returns value of mean function"
+        """
+        Returns value of mean function
+
+        Method to compute the value of the mean function for the inputs and parameters provided.
+        Shapes of ``x`` and ``params`` must be consistent based on the return value of the
+        ``get_n_params`` method. Returns a numpy array of shape ``(x.shape[0],)`` holding
+        the value of the mean function for each input point.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function evaluated at all input points, numpy array of shape
+                  ``(x.shape[0],)``
+        :rtype: ndarray
+        """
 
         raise NotImplementedError("base mean function does not implement a particular function")
 
     def mean_deriv(self, x, params):
-        "returns derivative of mean function wrt params"
+        """
+        Returns value of mean function derivative wrt the parameters
+
+        Method to compute the value of the mean function derivative with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, x.shape[0])`` holding the value of the mean
+        function derivative with respect to each parameter (first axis) for each input point
+        (second axis).
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         raise NotImplementedError("base mean function does not implement a particular function")
 
     def mean_hessian(self, x, params):
-        "returns hessian of mean function wrt params"
+        """
+        Returns value of mean function hessian wrt the parameters
+
+        Method to compute the value of the mean function Hessian with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, n_params, x.shape[0])`` holding the value
+        of the mean function second derivaties with respect to each parameter pair (first twp axes)
+        for each input point (last axis).
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function Hessian with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_parmas, n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         raise NotImplementedError("base mean function does not implement a particular function")
 
     def mean_inputderiv(self, x, params):
-        "returns derivative of mean function wrt inputs"
+        """
+        Returns value of mean function derivative wrt the inputs
+
+        Method to compute the value of the mean function derivative with respect to the
+        inputs for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(x.shape[1], x.shape[0])`` holding the value of the mean
+        function derivative with respect to each input (first axis) for each input point
+        (second axis).
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the inputs evaluated
+                  at all input points, numpy array of shape ``(x.shape[1], x.shape[0])``
+        :rtype: ndarray
+        """
 
         raise NotImplementedError("base mean function does not implement a particular function")
 
     def __add__(self, other):
-        "combines two mean functions"
+        """
+        Adds two mean functions
+
+        This method adds two mean functions, returning a ``MeanSum`` object. If the second
+        argument is a float or integer, it is converted to a ``ConstantMean`` object. If
+        the second argument is neither a subclass of ``MeanFunction`` nor a float/int,
+        an exception is raised.
+
+        :param other: Second ``MeanFunction`` (or float/integer) to be added
+        :type other: subclass of MeanFunction or float or int
+        :returns: ``MeanSum`` instance
+        :rtype: MeanSum
+        """
 
         if issubclass(type(other), MeanFunction):
             return MeanSum(self, other)
@@ -56,7 +191,19 @@ class MeanFunction(object):
             raise TypeError("other function cannot be added with a MeanFunction")
 
     def __radd__(self, other):
-        "combines two mean functions"
+        """
+        Right adds two mean functions
+
+        This method adds two mean functions, returning a ``MeanSum`` object. If the second
+        argument is a float or integer, it is converted to a ``ConstantMean`` object. If
+        the second argument is neither a subclass of ``MeanFunction`` nor a float/int,
+        an exception is raised.
+
+        :param other: Second ``MeanFunction`` (or float/integer) to be added
+        :type other: subclass of MeanFunction or float or int
+        :returns: ``MeanSum`` instance
+        :rtype: MeanSum
+        """
 
         if issubclass(type(other), MeanFunction):
             return MeanSum(other, self)
@@ -66,27 +213,62 @@ class MeanFunction(object):
             raise TypeError("other function cannot be added with a MeanFunction")
 
     def __mul__(self, other):
-        "multiplies two mean functions"
+        """
+        Multiplies two mean functions
+
+        This method multiples two mean functions, returning a ``MeanProduct`` object. If
+        the second argument is a float or integer, it is converted to a ``ConstantMean``
+        object. If the second argument is neither a subclass of ``MeanFunction`` nor a
+        float/int, an exception is raised.
+
+        :param other: Second ``MeanFunction`` (or float/integer) to be multiplied
+        :type other: subclass of MeanFunction or float or int
+        :returns: ``MeanProduct`` instance
+        :rtype: MeanProduct
+        """
 
         if issubclass(type(other), MeanFunction):
             return MeanProduct(self, other)
         elif isinstance(other, (float, int)):
             return MeanProduct(self, ConstantMean(other))
         else:
-            raise TypeError("other function cannot be added with a MeanFunction")
+            raise TypeError("other function cannot be multiplied with a MeanFunction")
 
     def __rmul__(self, other):
-        "multiplies two mean functions"
+        """
+        Right multiplies two mean functions
+
+        This method multiples two mean functions, returning a ``MeanProduct`` object. If
+        the second argument is a float or integer, it is converted to a ``ConstantMean``
+        object. If the second argument is neither a subclass of ``MeanFunction`` nor a
+        float/int, an exception is raised.
+
+        :param other: Second ``MeanFunction`` (or float/integer) to be multiplied
+        :type other: subclass of MeanFunction or float or int
+        :returns: ``MeanProduct`` instance
+        :rtype: MeanProduct
+        """
 
         if issubclass(type(other), MeanFunction):
             return MeanProduct(other, self)
         elif isinstance(other, (float, int)):
             return MeanProduct(ConstantMean(other), self)
         else:
-            raise TypeError("other function cannot be added with a MeanFunction")
+            raise TypeError("other function cannot be multipled with a MeanFunction")
 
     def __call__(self, other):
-        "composes two mean functions"
+        """
+        Composes two mean functions
+
+        This method multiples two mean functions, returning a ``MeanComposite`` object.
+        If the second argument is not a subclass of ``MeanFunction``, an exception is
+        raised.
+
+        :param other: Second ``MeanFunction`` to be composed
+        :type other: subclass of MeanFunction
+        :returns: ``MeanComposite`` instance
+        :rtype: MeanComposite
+        """
 
         if issubclass(type(other), MeanFunction):
             return MeanComposite(self, other)

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -454,6 +454,21 @@ class MeanSum(MeanFunction):
 
 class MeanProduct(MeanFunction):
     def __init__(self, f1, f2):
+        """
+        Class representing the product of two mean functions
+
+        This derived class represents the product of two mean functions, and does the necessary
+        bookkeeping needed to compute the required function and derivatives. The code does
+        not do any checks to confirm that it makes sense to multiply these particular mean functions --
+        in particular, multiplying two ``Coefficient`` classes is the same as having a single
+        one, but the code will not attempt to simplify this so it is up to the user to get it
+        right.
+
+        :iparam f1: first ``MeanFunction`` to be multiplied
+        :type f1: subclass of MeanFunction
+        :iparam f2: second ``MeanFunction`` to be multiplied
+        :type f2: subclass of MeanFunction
+        """
 
         if not issubclass(type(f1), MeanFunction):
             raise TypeError("inputs to MeanProduct must be subclasses of MeanFunction")
@@ -464,10 +479,40 @@ class MeanProduct(MeanFunction):
         self.f2 = f2
 
     def get_n_params(self, x):
+        """
+        Determine the number of parameters
+
+        Returns the number of parameters for the mean function, which possibly depends on x.
+
+        :param x: Input array
+        :type x: ndarray
+        :returns: number of parameters
+        :rtype: int
+        """
         return self.f1.get_n_params(x) + self.f2.get_n_params(x)
 
     def mean_f(self, x, params):
-        "returns value of mean function"
+        """
+        Returns value of mean function
+
+        Method to compute the value of the mean function for the inputs and parameters provided.
+        Shapes of ``x`` and ``params`` must be consistent based on the return value of the
+        ``get_n_params`` method. Returns a numpy array of shape ``(x.shape[0],)`` holding
+        the value of the mean function for each input point.
+
+        For ``MeanProduct``, this method applies the product rule to the results of computing
+        the mean for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function evaluated at all input points, numpy array of shape
+                  ``(x.shape[0],)``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 
@@ -475,7 +520,29 @@ class MeanProduct(MeanFunction):
                 self.f2.mean_f(x, params[switch:]))
 
     def mean_deriv(self, x, params):
-        "returns derivative of mean function wrt params"
+        """
+        Returns value of mean function derivative wrt the parameters
+
+        Method to compute the value of the mean function derivative with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, x.shape[0])`` holding the value of the mean
+        function derivative with respect to each parameter (first axis) for each input point
+        (second axis).
+
+        For ``MeanProduct``, this method applies the product rule to the results of computing
+        the derivative for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 
@@ -490,7 +557,29 @@ class MeanProduct(MeanFunction):
         return deriv
 
     def mean_hessian(self, x, params):
-        "returns hessian of mean function wrt params"
+        """
+        Returns value of mean function Hessian wrt the parameters
+
+        Method to compute the value of the mean function Hessian with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, n_params, x.shape[0])`` holding the value
+        of the mean function second derivaties with respect to each parameter pair (first twp axes)
+        for each input point (last axis).
+
+        For ``MeanProduct``, this method applies the product rule to the results of computing
+        the Hessian for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function Hessian with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_parmas, n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 
@@ -508,7 +597,29 @@ class MeanProduct(MeanFunction):
 
 
     def mean_inputderiv(self, x, params):
-        "returns derivative of mean function wrt inputs"
+        """
+        Returns value of mean function derivative wrt the inputs
+
+        Method to compute the value of the mean function derivative with respect to the
+        inputs for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(x.shape[1], x.shape[0])`` holding the value of the mean
+        function derivative with respect to each input (first axis) for each input point
+        (second axis).
+
+        For ``MeanProduct``, this method applies the product rule to the results of computing
+        the derivative for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the inputs evaluated
+                  at all input points, numpy array of shape ``(x.shape[1], x.shape[0])``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -796,9 +796,37 @@ class MeanComposite(MeanFunction):
                 self.f2.mean_inputderiv(x, params[switch:]))
 
 class FixedMean(MeanFunction):
-    "a mean function with a fixed function/derivative and no fitting parameters"
-    def __init__(self, f, deriv=None):
+    """
+    Class representing a fixed mean function with no parameters
 
+    Class representing a mean function with a fixed function (and optional derivative)
+    and no fitting parameters. The user must provide these functions when initializing
+    the instance.
+
+    :iparam f: fixed mean function, must be callable and take a single argument (the inputs)
+    :type f: function
+    :iparam deriv: fixed derivative function (optional if no derivatives are needed), must
+                   be callable and take a single argument (the inputs)
+    :type deriv: function or None
+    """
+    def __init__(self, f, deriv=None):
+        """
+        Initialize a class instance representing a fixed mean function with no parameters
+
+        Create a class instance representing a mean function with a fixed function
+        (and optional derivative) and no fitting parameters. The user must provide these
+        functions, though the derivative is optional. The code will check that the provided
+        arguments are callable, but will not confirm that the inputs and outputs are the
+        correct type/shape.
+
+        :param f: fixed mean function, must be callable and take a single argument (the inputs)
+        :type f: function
+        :param deriv: fixed derivative function (optional if no derivatives are needed), must
+                       be callable and take a single argument (the inputs)
+        :type deriv: function or None
+        :returns: new ``FixedMean`` instance
+        :rtype: FixedMean
+        """
         assert callable(f), "fixed mean function must be a callable function"
         if not deriv is None:
             assert callable(deriv), "mean function derivative must be a callable function"
@@ -807,27 +835,123 @@ class FixedMean(MeanFunction):
         self.deriv = deriv
 
     def get_n_params(self, x):
+        """
+        Determine the number of parameters
+
+        Returns the number of parameters for the mean function, which possibly depends on x.
+        For a ``FixedMean`` class, this is zero.
+
+        :param x: Input array
+        :type x: ndarray
+        :returns: number of parameters
+        :rtype: int
+        """
         return 0
 
     def mean_f(self, x, params):
+        """
+        Returns value of mean function
+
+        Method to compute the value of the mean function for the inputs and parameters provided.
+        Shapes of ``x`` and ``params`` must be consistent based on the return value of the
+        ``get_n_params`` method. For ``FixedMean`` classes, there are no parameters so the
+        ``params`` argument should be an array of length zero. Returns a numpy array of shape
+        ``(x.shape[0],)`` holding the value of the mean function for each input point.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input (zero in this case)
+        :type params: ndarray
+        :returns: Value of mean function evaluated at all input points, numpy array of shape
+                  ``(x.shape[0],)``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
         return self.f(x)
 
     def mean_deriv(self, x, params):
+        """
+        Returns value of mean function derivative wrt the parameters
+
+        Method to compute the value of the mean function derivative with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        For ``FixedMean`` classes, there are no parameters so the ``params`` argument
+        should be an array of length zero. Returns a numpy array of shape
+        ``(n_params, x.shape[0])`` holding the value of the mean function derivative with
+        respect to each parameter (first axis) for each input point (second axis). Since
+        fixed means have no parameters, this will just be an array of zeros.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
         return np.zeros((self.get_n_params(x), x.shape[0]))
 
     def mean_hessian(self, x, params):
+        """
+        Returns value of mean function Hessian wrt the parameters
+
+        Method to compute the value of the mean function Hessian with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        For ``FixedMean`` classes, there are no parameters so the ``params`` argument
+        should be an array of length zero. Returns a numpy array of shape
+        ``(n_params, n_params, x.shape[0])`` holding the value of the mean function
+        second derivaties with respect to each parameter pair (first twp axes) for each
+        input point (last axis). Since fixed means have no parameters, this will just
+        be an array of zeros.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function Hessian with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_parmas, n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 
         return np.zeros((self.get_n_params(x), self.get_n_params(x), x.shape[0]))
 
     def mean_inputderiv(self, x, params):
+        """
+        Returns value of mean function derivative wrt the inputs
+
+        Method to compute the value of the mean function derivative with respect to the
+        inputs for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        For ``FixedMean`` classes, there are no parameters so the ``params`` argument
+        should be an array of length zero. Returns a numpy array of shape
+        ``(x.shape[1], x.shape[0])`` holding the value of the mean function derivative
+        with respect to each input (first axis) for each input point (second axis).
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the inputs evaluated
+                  at all input points, numpy array of shape ``(x.shape[1], x.shape[0])``
+        :rtype: ndarray
+        """
 
         x, params = self._check_inputs(x, params)
 

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -122,7 +122,7 @@ class MeanFunction(object):
 
     def mean_hessian(self, x, params):
         """
-        Returns value of mean function hessian wrt the parameters
+        Returns value of mean function Hessian wrt the parameters
 
         Method to compute the value of the mean function Hessian with respect to the
         parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
@@ -276,8 +276,35 @@ class MeanFunction(object):
             raise TypeError("other function cannot be composed with a MeanFunction")
 
 class MeanSum(MeanFunction):
-    def __init__(self, f1, f2):
+    """
+    Class representing the sum of two mean functions
 
+    This derived class represents the sum of two mean functions, and does the necessary
+    bookkeeping needed to compute the required function and derivatives. The code does
+    not do any checks to confirm that it makes sense to add these particular mean functions --
+    in particular, adding two ``Coefficient`` classes is the same as having a single
+    one, but the code will not attempt to simplify this so it is up to the user to get it
+    right.
+
+    :iparam f1: first ``MeanFunction`` to be added
+    :type f1: subclass of MeanFunction
+    :iparam f2: second ``MeanFunction`` to be added
+    :type f2: subclass of MeanFunction
+    """
+    def __init__(self, f1, f2):
+        """
+        Create a new instance of two added mean functions
+
+        Creates an instance of to added mean functions. Inputs are the two functions
+        to be added, which must be a subclass of the base ``MeanFunction`` class.
+
+        :param f1: first ``MeanFunction`` to be added
+        :type f1: subclass of MeanFunction
+        :param f2: second ``MeanFunction`` to be added
+        :type f2: subclass of MeanFunction
+        :returns: new ``MeanSum`` instance
+        :rtype: MeanSum
+        """
         if not issubclass(type(f1), MeanFunction):
             raise TypeError("inputs to MeanSum must be subclasses of MeanFunction")
         if not issubclass(type(f2), MeanFunction):
@@ -287,10 +314,40 @@ class MeanSum(MeanFunction):
         self.f2 = f2
 
     def get_n_params(self, x):
+        """
+        Determine the number of parameters
+
+        Returns the number of parameters for the mean function, which possibly depends on x.
+
+        :param x: Input array
+        :type x: ndarray
+        :returns: number of parameters
+        :rtype: int
+        """
         return self.f1.get_n_params(x) + self.f2.get_n_params(x)
 
     def mean_f(self, x, params):
-        "returns value of mean function"
+        """
+        Returns value of mean function
+
+        Method to compute the value of the mean function for the inputs and parameters provided.
+        Shapes of ``x`` and ``params`` must be consistent based on the return value of the
+        ``get_n_params`` method. Returns a numpy array of shape ``(x.shape[0],)`` holding
+        the value of the mean function for each input point.
+
+        For ``MeanSum``, this method applies the sum rule to the results of computing
+        the mean for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function evaluated at all input points, numpy array of shape
+                  ``(x.shape[0],)``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 
@@ -298,7 +355,29 @@ class MeanSum(MeanFunction):
                 self.f2.mean_f(x, params[switch:]))
 
     def mean_deriv(self, x, params):
-        "returns derivative of mean function wrt params"
+        """
+        Returns value of mean function derivative wrt the parameters
+
+        Method to compute the value of the mean function derivative with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, x.shape[0])`` holding the value of the mean
+        function derivative with respect to each parameter (first axis) for each input point
+        (second axis).
+
+        For ``MeanSum``, this method applies the sum rule to the results of computing
+        the derivative for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 
@@ -310,7 +389,29 @@ class MeanSum(MeanFunction):
         return deriv
 
     def mean_hessian(self, x, params):
-        "returns hessian of mean function wrt params"
+        """
+        Returns value of mean function Hessian wrt the parameters
+
+        Method to compute the value of the mean function Hessian with respect to the
+        parameters for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(n_params, n_params, x.shape[0])`` holding the value
+        of the mean function second derivaties with respect to each parameter pair (first twp axes)
+        for each input point (last axis).
+
+        For ``MeanSum``, this method applies the sum rule to the results of computing
+        the Hessian for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function Hessian with respect to the parameters evaluated
+                  at all input points, numpy array of shape ``(n_parmas, n_params, x.shape[0])``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 
@@ -322,7 +423,29 @@ class MeanSum(MeanFunction):
         return hess
 
     def mean_inputderiv(self, x, params):
-        "returns derivative of mean function wrt inputs"
+        """
+        Returns value of mean function derivative wrt the inputs
+
+        Method to compute the value of the mean function derivative with respect to the
+        inputs for the inputs and parameters provided. Shapes of ``x`` and ``params``
+        must be consistent based on the return value of the ``get_n_params`` method.
+        Returns a numpy array of shape ``(x.shape[1], x.shape[0])`` holding the value of the mean
+        function derivative with respect to each input (first axis) for each input point
+        (second axis).
+
+        For ``MeanSum``, this method applies the sum rule to the results of computing
+        the derivative for the individual functions.
+
+        :param x: Inputs, must be a 1D or 2D numpy array (if 1D a second dimension will be added)
+        :type x: ndarray
+        :param params: Parameters, must be a 1D numpy array (of more than 1D will be flattened)
+                       and have the same length as the number of parameters required for the
+                       provided input
+        :type params: ndarray
+        :returns: Value of mean function derivative with respect to the inputs evaluated
+                  at all input points, numpy array of shape ``(x.shape[1], x.shape[0])``
+        :rtype: ndarray
+        """
 
         switch = self.f1.get_n_params(x)
 

--- a/mogp_emulator/formula.py
+++ b/mogp_emulator/formula.py
@@ -6,7 +6,60 @@ except ImportError:
     no_patsy = True
 
 def mean_from_patsy_formula(formula, inputdict={}):
-    "use patsy to parse formula before evaluating terms"
+    """
+    Create a mean function from a patsy formula
+
+    This is the functional interface to creating a mean function from a patsy/R formula.
+    The higher level function ``MeanFunction`` in the ``MeanFunction`` module is preferred
+    over this one, but this potentially gives the user slightly more control as a
+    patsy ``ModelDesc`` object can be passed directly, rather than giving a string.
+
+    This method takes a string or a patsy ``ModelDesc`` object as an input and an optional
+    dictionary that map strings to integer indices in the input data. The formula is then
+    parsed with patsy, and the individual terms resulting from that are converted to
+    mean functions and composed using the provided operations.
+
+    The string formulas can be specified in several ways. The formula LHS is implicitly
+    always ``"y = "`` or ``"y ~ "``, though these can be explicitly provided as well
+    (though it is ignored in the conversion). The RHS may contain a set of terms
+    containing the add, multiply, power, and call operations much in the same way
+    that the operations would be entered as regular python code. Parentheses are
+    used to indicated prececence as well as the call operation, and square brackets
+    indicate an indexing operation on the inputs. Inputs may be specified as either
+    a string such as ``"x[0]"``, ``"inputs[0]"``, or a string that can be mapped to
+    an integer index with the optional dictionary passed to the function. Any strings
+    not representing operations or inputs as described above are interpreted as follows:
+    if the string can be converted into a number, then it is interpreted as a
+    ``ConstantMean`` fixed mean function object; otherwise it is assumed to represent
+    a fitting coefficient. Note that this means many characters that do not represent
+    operations within this mean function language but would not normally be considered
+    as python variables will nonetheless be converted into fitting coefficients --
+    it is up to the user to get this right.
+
+    Expressions that are repeated or redundant will not be simplified beyond the parsing
+    done by patsy, so the user should take care that the provided expression is sensible
+    as a mean function and will not cause problems when fitting.
+
+    Examples: ::
+
+        >>> from mogp_emulator.formula import mean_from_patsy_formula
+        >>> mf1 = mean_from_patsy_formula("x[0]")
+        >>> print(mf1)
+        c + c*x[0]
+        >>> mf2 = mean_from_patsy_formula("a*b", {"a": 0, "b": 1})
+        >>> print(mf2)
+        c + c*x[0] + c*x[1] + c*x[0]*x[1]
+
+    :param formula: string representing the desired mean function formula
+                    or a patsy ``ModelDesc`` object
+    :type formula: str or ModelDesc
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :returns: New subclass of ``MeanBase`` implementing the given formula
+    :rtype: subclass of MeanBase (exact type will depend on the formula that is provided)
+    """
 
     assert not no_patsy, "patsy must be installed to parse formulas using patsy"
 
@@ -31,12 +84,61 @@ def mean_from_patsy_formula(formula, inputdict={}):
 
     return mf
 
-def mean_from_string(inputstr, inputdict={}):
-    "convert a string formula into a MeanFunction object"
+def mean_from_string(formula, inputdict={}):
+    """
+    Create a mean function from a string formula
 
-    assert isinstance(inputstr, str)
+    This is the functional interface to creating a mean function from a string formula.
+    The higher level function ``MeanFunction`` in the ``MeanFunction`` module is preferred
+    over this one, but this can also be used and the output is identical.
 
-    tokens = tokenize_string(inputstr)
+    This method takes a string as an input and an optional dictionary that map strings to
+    integer indices in the input data.
+
+    The string formulas can be specified in several ways. The formula LHS is implicitly
+    always ``"y = "`` or ``"y ~ "``, though these can be explicitly provided as well.
+    The RHS may contain a set of terms containing the add, multiply, power, and
+    call operations much in the same way that the operations would be entered as
+    regular python code. Parentheses are used to indicated prececence as well as
+    the call operation, and square brackets indicate an indexing operation on the
+    inputs. Inputs may be specified as either a string such as ``"x[0]"``,
+    ``"inputs[0]"``, or a string that can be mapped to an integer index with the
+    optional dictionary passed to the function. Any strings not representing operations
+    or inputs as described above are interpreted as follows: if the string can
+    be converted into a number, then it is interpreted as a ``ConstantMean`` fixed
+    mean function object; otherwise it is assumed to represent a fitting coefficient.
+    Note that this means many characters that do not represent operations within this
+    mean function language but would not normally be considered as python variables
+    will nonetheless be converted into fitting coefficients -- it is up to the user
+    to get this right.
+
+    Expressions that are repeated or redundant will not be simplified, so the user should
+    take care that the provided expression is sensible as a mean function and will not
+    cause problems when fitting.
+
+    Examples: ::
+
+        >>> from mogp_emulator.formula import mean_from_string
+        >>> mf1 = mean_from_string("y = a + b*x[0]")
+        >>> print(mf1)
+        c + c*x[0]
+        >>> mf2 = mean_from_string("c*a*b", {"a": 0, "b": 1})
+        >>> print(mf2)
+        c*x[0]*x[1]
+
+    :param formula: string representing the desired mean function formula
+    :type formula: str
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :returns: New subclass of ``MeanBase`` implementing the given formula
+    :rtype: subclass of MeanBase (exact type will depend on the formula that is provided)
+    """
+
+    assert isinstance(formula, str)
+
+    tokens = tokenize_string(formula)
     eval_stack = parse_tokens(tokens)
 
     mf = eval_parsed_tokens(eval_stack, inputdict)
@@ -46,7 +148,26 @@ def mean_from_string(inputstr, inputdict={}):
     return mf
 
 def term_to_mean(term, inputdict={}):
-    "convert a patsy Term object into a MeanFunction object"
+    """
+    Convert a patsy Term object into a mean function object
+
+    Converts an individual term to a subclass of ``MeanBase`` appropriate for the
+    formula (either will be a ``Coefficient`` or a ``MeanProduct`` instance).
+    An implicit ``Coefficient`` is included, and then the results from parsing
+    each of the factors in the term are multiplied by the coefficient. Variable
+    substutions are done using the provided ``inputdict``, mapping strings
+    to indices in the inputs, if there is one. Returns the mean function object
+    appropriate for this term.
+
+    :param term: patsy ``Term`` object
+    :type formula: Term
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :returns: New subclass of ``MeanBase`` implementing the given term
+    :rtype: subclass of MeanBase (exact type will depend on the formula that is provided)
+    """
 
     assert not no_patsy, "patsy must be installed to parse formulas using patsy"
 
@@ -64,54 +185,90 @@ def term_to_mean(term, inputdict={}):
 
     return mf
 
-def parse_factor_code(code, inputdict={}):
+def convert_token(token, inputdict={}):
     """
-    replaces given string with aliases from inputdict and converts inputs -> x
+    Converts an individual token into inputs
+
+    Converts an individual token from the tokenizer to a dependent variable,
+    making replacements if the given string has aliases. These include any
+    strings found in the provided dictionary and converts ``'inputs'`` to
+    ``'x'`` as this is an implicit alias.
+
+    :param token: string token to be converted
+    :type str:
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :returns: converted string token if any substitutions were found, otherwise
+              the same token is returned
+    :rtype: str
     """
 
-    assert isinstance(code, str), "formula input to mean function is not a string"
+    assert isinstance(token, str), "formula input to mean function is not a string"
 
-    if code[:6] == "inputs":
-        newcode = "x"+code[6:]
-    elif code in inputdict:
-        newcode = "x[{}]".format(inputdict[code])
+    if token[:6] == "inputs":
+        newtoken = "x"+token[6:]
+    elif token in inputdict:
+        newtoken = "x[{}]".format(inputdict[token])
     else:
-        newcode = code
+        newtoken = token
 
-    return newcode
+    return newtoken
 
 def _is_float(val):
-    "checks if a token can be converted into a float"
+    """
+    Checks if a token can be converted into a float
+
+    Returns a boolean indicating if the given token can be converted to a float
+
+    :param val: input to be tested, meant to be a string but can be any type
+    :type val: string (though any other type is also acceptable)
+    :returns: boolean indicating if input can be converted to a float
+    :rtype: bool
+    """
     try:
         float(val)
     except ValueError:
         return False
     return True
 
-def inputstr_to_mean(inputstr, inputdict={}):
+def token_to_mean(token, inputdict={}):
     """
-    convert a string to a mean function
+    Convert an individual token to a mean function
 
-    makes substitutions found in inputdict to map variable names to indices
-    converts numeric tokens to constant means
-    any other strings not in inputdict are assumed to represent coefficients
+    Function to convert a single non-operator token to a mean function.
+    Makes substitutions found in the provided dictionary (if present)
+    to map variable names to indices. Converts numeric tokens to ``ConstantMean``
+    objects, tokens that can be converted into inputs to ``LinearMean`` objects,
+    and any other strings not found inputdict are assumed to represent
+    coefficients and will be converted to ``Coefficient`` objects.
+
+    :param token: string token to be converted
+    :type: token: str
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :returns: New subclass of ``MeanBase`` implementing the given token
+    :rtype: subclass of MeanBase (exact type will depend on the token)
     """
 
-    assert isinstance(inputstr, str), "formula input to mean function is not a string"
+    assert isinstance(token, str), "formula input to mean function is not a string"
 
-    if _is_float(inputstr):
-        return MeanFunction.ConstantMean(float(inputstr))
+    if _is_float(token):
+        return MeanFunction.ConstantMean(float(token))
 
-    inputstr = parse_factor_code(inputstr, inputdict)
+    token = convert_token(token, inputdict)
 
-    if not inputstr[0] == "x":
+    if not token[0] == "x":
         return MeanFunction.Coefficient()
 
-    if not (inputstr[:2] == "x[" and inputstr[-1] == "]"):
+    if not (token[:2] == "x[" and token[-1] == "]"):
         raise ValueError("bad formula input in mean function")
 
     try:
-        index = int(inputstr[2:-1])
+        index = int(token[2:-1])
     except ValueError:
         raise ValueError("index in parsed formula is not an integer")
 
@@ -119,15 +276,31 @@ def inputstr_to_mean(inputstr, inputdict={}):
 
     return MeanFunction.LinearMean(index)
 
-def tokenize_string(string):
-    "converts a string into a series of tokens for evaluation"
+def tokenize_string(formula):
+    """
+    Converts a string formula into a series of tokens for evaluation
 
-    assert isinstance(string, str)
+    Takes a string and divides it into a list of individual string tokens.
+    Special tokens include ``"(", ")", "+", "^", "[", "]", "=", "~"``,
+    where these have the expected Python behavior, with ``"="`` and ``"~"``
+    separating the LHS and RHS of the formula. All other special characters
+    are considered to be non-special in this language and will only be split
+    up based on whitespace. The LHS and all white space are removed. Note
+    also that ``"call"`` is a protected keyword here, as it is used to
+    designate a function call operation.
+
+    :param formula: string formula to be parsed
+    :type formula: str
+    :returns: list of parsed string tokens
+    :rtype: list
+    """
+
+    assert isinstance(formula, str)
 
     token_list = []
     accumulated = ""
 
-    for char in string:
+    for char in formula:
         if char in ["(", ")", "+", "^", " ", "[", "]", "=", "~"]:
             if not accumulated == "":
                 token_list.append(accumulated)
@@ -179,7 +352,20 @@ def tokenize_string(string):
     return outlist
 
 def parse_tokens(token_list):
-    "parses a list of tokens into an RPN sequence of operations"
+    """
+    Parses a list of tokens, converting into an RPN sequence of operations
+
+    Takes a list of string tokens and returns a list of string tokens only
+    containing binary operators (``"+", "*", "^", "call"``) and objects on
+    which to operate. Order of operations is denoted by Reverse Polish
+    Notation, where operations take place on a stack. Uses an adapted
+    shunting-yard algorithm.
+
+    :param token_list: list of tokens to be parsed into a sequence of operations
+    :type token_list: list
+    :returns: list of operators and objects on which to operate
+    :rtype: list
+    """
 
     assert isinstance(token_list, list), "input must be a list of strings"
 
@@ -232,7 +418,29 @@ def parse_tokens(token_list):
     return output_list
 
 def eval_parsed_tokens(token_list, inputdict={}):
-    "evaluate parsed tokens into a mean function"
+    """
+    Evaluate parsed tokens into a mean function
+
+    Evaluates the parsed token list, returning the mean function represented by these
+    operations. Input must be a list of strings that come from the ``parse_tokens``
+    function, though it will accept any list of strings for processing.
+
+    The function evaluates the sequence of operators and objects on which the operations
+    are performed by placing them on a stack and evaluating assuming Reverse Polish
+    Notation. The objects are converted to mean function objects when they are placed on
+    the stack, and if the stack ever does not contain a valid sequence of operations,
+    a ``SyntaxError``is raised. Additionally, if at the end of all operations there is not
+    a single mean function object on the stack, a ``SyntaxError`` is raised.
+
+    :param token_list: list of tokens to be parsed into a sequence of operations
+    :type token_list: list
+    :param inputdict: dictionary used to map variables to input indices. Maps
+                      strings to integer indices (must be non-negative). Optional,
+                      default is ``{}``.
+    :type inputdict: dict
+    :returns: New subclass of ``MeanBase`` implementing the given set of operations
+    :rtype: subclass of MeanBase (exact type will depend on the sequence)
+    """
 
     assert isinstance(token_list, list), "input must be a list of strings"
 
@@ -248,7 +456,7 @@ def eval_parsed_tokens(token_list, inputdict={}):
             if token == "I":
                 mf = "I"
             else:
-                mf = inputstr_to_mean(token, inputdict)
+                mf = token_to_mean(token, inputdict)
             stack.append(mf)
         else:
             if len(stack) < 2:

--- a/mogp_emulator/formula.py
+++ b/mogp_emulator/formula.py
@@ -157,11 +157,15 @@ def tokenize_string(string):
         elif item == "[":
             outlist.append(outlist.pop()+item)
         elif item == "]":
+            if len(outlist) < 2:
+                raise SyntaxError("error in using square brackets in formula input")
             outlist.append(outlist.pop(-2)+outlist.pop()+item)
 
     for item in outlist:
         if (not "[" in item and "]" in item) or (not "]" in item and "[" in item):
             raise SyntaxError("cannot nest operators in square brackets in formula input")
+        if item == "call":
+            raise SyntaxError("'call' cannot be used as a variable name in formula input")
 
     return outlist
 
@@ -240,14 +244,14 @@ def eval_parsed_tokens(token_list, inputdict={}):
             op_2 = stack.pop()
             if op_2 == "I":
                 raise SyntaxError("identity operator can only be called as a function")
-            assert issubclass(type(op_2), MeanFunction)
+            assert issubclass(type(op_2), MeanFunction.MeanFunction)
             op_1 = stack.pop()
             if token == "call":
-                assert op_1 == "I" or issubclass(type(op_1), MeanFunction)
+                assert op_1 == "I" or issubclass(type(op_1), MeanFunction.MeanFunction)
             else:
-                if op_2 == "I":
+                if op_1 == "I":
                     raise SyntaxError("identity operator can only be called as a function")
-                assert issubclass(type(op_1), MeanFunction), "expression was not c"
+                assert issubclass(type(op_1), MeanFunction.MeanFunction)
 
             if token == "+":
                 stack.append(op_1.__add__(op_2))

--- a/mogp_emulator/formula.py
+++ b/mogp_emulator/formula.py
@@ -1,0 +1,114 @@
+from .MeanFunction import MeanFunction, ConstantMean, LinearMean, Coefficient
+try:
+    import patsy
+except ImportError:
+    raise ImportError("you must install patsy to convert formulas to mean functions")
+
+def mean_from_formula(formula, inputdict={}):
+    "function to create a mean function from a formula or patsy ModelDesc"
+
+    if formula is None or (isinstance(formula, str) and formula.strip() == ""):
+        return ConstantMean(0.)
+
+    if isinstance(formula, str):
+        model = patsy.ModelDesc.from_formula(formula)
+    elif isinstance(formula, patsy.ModelDesc):
+        model = formula
+
+    model_terms = []
+
+    for term in model.rhs_termlist:
+        model_terms.append(term_to_mean(term, inputdict))
+
+    mf = model_terms.pop(0)
+
+    assert issubclass(type(mf), MeanFunction)
+
+    for term in model_terms:
+        mf += term
+
+    assert issubclass(type(mf), MeanFunction)
+
+    return mf
+
+def term_to_mean(term, inputdict={}):
+    "convert a patsy Term object into a MeanFunction object"
+
+    assert isinstance(term, patsy.Term)
+
+    # add leading coefficient and multiply by all factors
+
+    mf = Coefficient()
+
+    for factor in term.factors:
+        mf *= factor_to_mean(factor, inputdict)
+
+    assert issubclass(type(mf), MeanFunction)
+
+    return mf
+
+def factor_to_mean(factor, inputdict={}):
+    "convert a patsy Factor object into a MeanFunction object"
+
+    assert isinstance(factor, patsy.EvalFactor)
+
+    tokens = parse_factor_code(factor.code, inputdict)
+
+    mf = tokens_to_mean(tokens)
+
+    assert issubclass(type(mf), MeanFunction)
+
+    return mf
+
+def parse_factor_code(code, inputdict={}):
+    """
+    turn code into tokens to be evaluated, making replacements from inputdict as appropriate
+
+    Currently does not do any complex parsing, only replaces terms found in inputdict
+    """
+
+    assert isinstance(code, str), "formula input to mean function is not a string"
+
+    if code[:6] == "inputs":
+        newcode = "x"+code[6:]
+    elif code in inputdict:
+        try:
+            index = int(inputdict[code])
+        except ValueError:
+            raise ValueError("provided dictionary does not map string to an integer index")
+        newcode = "x["+str(index)+"]"
+    else:
+        newcode = code
+
+    if not (newcode[:2] == "x[" and newcode[-1] == "]"):
+        raise ValueError("bad formula input in mean function")
+
+    return [newcode]
+
+def tokens_to_mean(tokenlist):
+    """
+    convert a list of tokens into a mean function
+
+    presently only works with single tokens representing linear terms in the input parameters
+    """
+
+    assert isinstance(tokenlist, list)
+
+    return inputstr_to_mean(tokenlist[0])
+
+def inputstr_to_mean(inputstr):
+    "convert a string containing a single input of the form x[<index>] to a mean function"
+
+    assert isinstance(inputstr, str), "formula input to mean function is not a string"
+
+    if not (inputstr[:2] == "x[" and inputstr[-1] == "]"):
+        raise ValueError("bad formula input in mean function")
+
+    try:
+        index = int(inputstr[2:-1])
+    except ValueError:
+        raise ValueError("index in parsed formula is not an integer")
+
+    assert index >= 0, "index in formula parsing must be non-negative"
+
+    return LinearMean(index)

--- a/mogp_emulator/formula.py
+++ b/mogp_emulator/formula.py
@@ -48,6 +48,8 @@ def mean_from_string(inputstr, inputdict={}):
 def term_to_mean(term, inputdict={}):
     "convert a patsy Term object into a MeanFunction object"
 
+    assert not no_patsy, "patsy must be installed to parse formulas using patsy"
+
     assert isinstance(term, Term)
 
     # add leading coefficient and multiply by all factors
@@ -210,7 +212,7 @@ def parse_tokens(token_list):
                     raise SyntaxError("string expression has mismatched parentheses")
             if operator_stack[-1] == "(":
                 operator_stack.pop()
-            prev_op = True
+            prev_op = False
 
     while len(operator_stack) > 0:
         operator = operator_stack.pop()

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -123,6 +123,29 @@ def test_MeanFunction_failures(mf, x, params):
     with pytest.raises(TypeError):
         mf(3.)
 
+def test_MeanFunction_from_formula():
+    "test the function to create a mean function from a formula"
+
+    mf = MeanFunction.from_formula(None)
+
+    assert isinstance(mf, ConstantMean)
+    assert_allclose(mf.mean_f(np.ones((2,3)), np.zeros(0)), np.zeros((2)))
+
+    mf2 = MeanFunction.from_formula("x[0]", use_patsy=True)
+
+    assert isinstance(mf2, MeanSum)
+    assert_allclose(mf2.mean_f(np.array([[1., 2., 3.], [4., 5., 6.]]), np.array([1., 2.])),
+                    np.array([3., 9.]))
+
+    mf3 = MeanFunction.from_formula("a + b*c", {"c":0}, use_patsy=False)
+
+    assert isinstance(mf3, MeanSum)
+    assert_allclose(mf3.mean_f(np.array([[1., 2., 3.], [4., 5., 6.]]), np.array([1., 2.])),
+                    np.array([3., 9.]))
+
+    with pytest.raises(ValueError):
+        MeanFunction.from_formula(1)
+
 def test_fixed_functions(x):
     "test utility functions for creating fixed means"
 

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from ..MeanFunction import MeanFunction, MeanSum, MeanProduct, FixedMean, ConstantMean, LinearMean
-from ..MeanFunction import PolynomialMean
+from ..MeanFunction import Coefficient, PolynomialMean, MeanComposite
+from ..MeanFunction import fixed_f, fixed_inputderiv, one, const_f, const_deriv
 
 @pytest.fixture
 def mf():
@@ -15,6 +16,14 @@ def x():
 @pytest.fixture
 def params():
     return np.array([1., 2., 4.])
+
+@pytest.fixture
+def zeroparams():
+    return np.zeros(0)
+
+@pytest.fixture
+def oneparams():
+    return np.ones(1)
 
 @pytest.fixture
 def dx():
@@ -30,12 +39,12 @@ def test_MeanFunction(mf, x, params):
     mf3 = 5. + mf
 
     assert isinstance(mf3, MeanSum)
-    assert isinstance(mf3.f1, FixedMean)
+    assert isinstance(mf3.f1, ConstantMean)
 
     mf4 = mf + 3.
 
     assert isinstance(mf4, MeanSum)
-    assert isinstance(mf4.f2, FixedMean)
+    assert isinstance(mf4.f2, ConstantMean)
 
     mf5 = mf*mf
 
@@ -44,12 +53,16 @@ def test_MeanFunction(mf, x, params):
     mf6 = 3.*mf
 
     assert isinstance(mf6, MeanProduct)
-    assert isinstance(mf6.f1, FixedMean)
+    assert isinstance(mf6.f1, ConstantMean)
 
     mf7 = mf*3.
 
     assert isinstance(mf7, MeanProduct)
-    assert isinstance(mf7.f2, FixedMean)
+    assert isinstance(mf7.f2, ConstantMean)
+
+    mf8 = mf(mf)
+
+    assert isinstance(mf8, MeanComposite)
 
 def test_MeanFunction_failures(mf, x, params):
     "test situations of MeanFunction where an exception should be raised"
@@ -81,10 +94,43 @@ def test_MeanFunction_failures(mf, x, params):
     with pytest.raises(TypeError):
         "3"*mf
 
-def test_FixedMean(x):
-    "test the FixedMean function"
+    with pytest.raises(TypeError):
+        mf(3.)
 
-    params = np.zeros(0)
+def test_fixed_functions(x):
+    "test utility functions for creating fixed means"
+
+    assert_allclose(fixed_f(np.ones((2,2)), 0, np.exp), np.exp(np.ones(2)))
+
+    with pytest.raises(AssertionError):
+        fixed_f(np.ones(3), 0, np.exp)
+    with pytest.raises(AssertionError):
+        fixed_f(np.ones((2,2)), -1, np.exp)
+    with pytest.raises(AssertionError):
+        fixed_f(np.ones((2,2)), 0, 1)
+    with pytest.raises(IndexError):
+        fixed_f(np.ones((2,2)), 3, np.exp)
+
+    inputderiv_exp = np.zeros((2,2))
+    inputderiv_exp[0] = np.exp(1.)
+
+    assert_allclose(fixed_inputderiv(np.ones((2,2)), 0, np.exp), inputderiv_exp)
+
+    with pytest.raises(AssertionError):
+        fixed_inputderiv(np.ones(3), 0, np.exp)
+    with pytest.raises(AssertionError):
+        fixed_inputderiv(np.ones((2,2)), -1, np.exp)
+    with pytest.raises(AssertionError):
+        fixed_inputderiv(np.ones((2,2)), 0, 1)
+    with pytest.raises(IndexError):
+        fixed_inputderiv(np.ones((2,2)), 3, np.exp)
+
+    assert_allclose(one(x), np.ones(x.shape))
+    assert_allclose(const_f(x, 2.), np.broadcast_to(2., (x.shape[0],)))
+    assert_allclose(const_deriv(x), np.zeros((x.shape[1], x.shape[0])))
+
+def test_FixedMean(x, zeroparams):
+    "test the FixedMean function"
 
     f = lambda x: np.ones(x.shape[0])
     deriv = lambda x: np.zeros((x.shape[1], x.shape[0]))
@@ -92,192 +138,273 @@ def test_FixedMean(x):
 
     assert fixed_mean.get_n_params(x) == 0
 
-    assert_allclose(fixed_mean.mean_f(x, params), np.ones(x.shape[0]))
-    assert_allclose(fixed_mean.mean_f(np.array([1., 2., 3.]), params), np.ones(3))
-    assert_allclose(fixed_mean.mean_deriv(x, params), np.zeros((0, x.shape[0])))
-    assert_allclose(fixed_mean.mean_hessian(x, params), np.zeros((0, 0, x.shape[0])))
-    assert_allclose(fixed_mean.mean_inputderiv(x, params), np.zeros((x.shape[1], x.shape[0])))
+    assert_allclose(fixed_mean.mean_f(x, zeroparams), np.ones(x.shape[0]))
+    assert_allclose(fixed_mean.mean_f(np.array([1., 2., 3.]), zeroparams), np.ones(3))
+    assert_allclose(fixed_mean.mean_deriv(x, zeroparams), np.zeros((0, x.shape[0])))
+    assert_allclose(fixed_mean.mean_hessian(x, zeroparams), np.zeros((0, 0, x.shape[0])))
+    assert_allclose(fixed_mean.mean_inputderiv(x, zeroparams), np.zeros((x.shape[1], x.shape[0])))
 
-def test_ConstantMean(x):
+    fixed_mean = FixedMean(f)
+
+    with pytest.raises(RuntimeError):
+        fixed_mean.mean_inputderiv(x, np.zeros(0))
+
+@pytest.mark.parametrize("val",[0., 1., 2.])
+def test_ConstantMean(x, zeroparams, val):
     "test the constant mean function"
 
-    params = np.ones(1)
+    constant_mean = ConstantMean(val)
 
-    constant_mean = ConstantMean()
+    assert constant_mean.get_n_params(x) == 0
 
-    assert constant_mean.get_n_params(x) == 1
+    assert_allclose(constant_mean.mean_f(x, zeroparams), np.broadcast_to(val, x.shape[0]))
+    assert_allclose(constant_mean.mean_deriv(x, zeroparams), np.zeros((0, x.shape[0])))
+    assert_allclose(constant_mean.mean_hessian(x, zeroparams), np.zeros((0, 0, x.shape[0])))
+    assert_allclose(constant_mean.mean_inputderiv(x, zeroparams), np.zeros((x.shape[1], x.shape[0])))
 
-    assert_allclose(constant_mean.mean_f(x, params), np.broadcast_to(1., x.shape[0]))
-    assert_allclose(constant_mean.mean_deriv(x, params), np.ones((1, x.shape[0])))
-    assert_allclose(constant_mean.mean_hessian(x, params), np.zeros((1, 1, x.shape[0])))
-    assert_allclose(constant_mean.mean_inputderiv(x, params), np.zeros((x.shape[1], x.shape[0])))
-
-def test_LinearMean(x, params, dx):
+@pytest.mark.parametrize("index", [0, 1])
+def test_LinearMean(x, zeroparams, dx, index):
     "test the linear mean function"
 
-    linear_mean = LinearMean()
+    linear_mean = LinearMean(index)
 
-    assert linear_mean.get_n_params(x) == 3
+    assert linear_mean.get_n_params(x) == 0
 
-    assert_allclose(linear_mean.mean_f(x, params), np.sum(x*params, axis=1))
-    assert_allclose(linear_mean.mean_deriv(x, params), np.transpose(x))
-    assert_allclose(linear_mean.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
-    assert_allclose(linear_mean.mean_inputderiv(x, params),
-                    np.broadcast_to(np.reshape(params, (-1, 1)), (x.shape[1], x.shape[0])))
+    inputderiv_expect = np.zeros((x.shape[1], x.shape[0]))
+    inputderiv_expect[index] = 1.
 
-    deriv_fd = np.zeros((3, 2))
-    deriv_fd[0] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([dx, 0., 0.])))/dx
-    deriv_fd[1] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([0., dx, 0.])))/dx
-    deriv_fd[2] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([0., 0., dx])))/dx
+    assert_allclose(linear_mean.mean_f(x, zeroparams), x[:,index])
+    assert_allclose(linear_mean.mean_deriv(x, zeroparams), np.zeros((0, x.shape[0])))
+    assert_allclose(linear_mean.mean_hessian(x, zeroparams), np.zeros((0, 0, x.shape[0])))
+    assert_allclose(linear_mean.mean_inputderiv(x, zeroparams), inputderiv_expect)
 
-    assert_allclose(linear_mean.mean_deriv(x, params), deriv_fd)
+    D = x.shape[1]
 
-    inputderiv_fd = np.zeros((3, 2))
-    inputderiv_fd[0] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x - np.array([dx, 0., 0.]), params))/dx
-    inputderiv_fd[1] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x - np.array([0., dx, 0.]), params))/dx
-    inputderiv_fd[2] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x - np.array([0., 0., dx]), params))/dx
+    inputderiv_fd = np.zeros((D, 2))
+    for i in range(D):
+        dx_array = np.zeros(D)
+        dx_array[i] = dx
+        inputderiv_fd[i] = (linear_mean.mean_f(x, zeroparams) -
+                            linear_mean.mean_f(x - dx_array, zeroparams))/dx
 
-    assert_allclose(linear_mean.mean_inputderiv(x, params), inputderiv_fd)
+    assert_allclose(linear_mean.mean_inputderiv(x, zeroparams), inputderiv_fd)
 
-def test_MeanSum(x, dx):
+def test_Coefficient(x, oneparams):
+    "test the Coefficient class"
+
+    coeff_mean = Coefficient()
+
+    assert coeff_mean.get_n_params(x) == 1
+
+    assert_allclose(coeff_mean.mean_f(x, oneparams), np.broadcast_to(1., x.shape[0]))
+    assert_allclose(coeff_mean.mean_deriv(x, oneparams), np.ones((1, x.shape[0])))
+    assert_allclose(coeff_mean.mean_hessian(x, oneparams), np.zeros((1, 1, x.shape[0])))
+    assert_allclose(coeff_mean.mean_inputderiv(x, oneparams), np.zeros((x.shape[1], x.shape[0])))
+
+    with pytest.raises(AssertionError):
+        coeff_mean._check_inputs(x, np.ones(4))
+
+    with pytest.raises(AssertionError):
+        coeff_mean._check_inputs(np.ones((2, 3, 2)), oneparams)
+
+def test_LinearMean_failures(x):
+    "test situations where LinearMean should fail"
+
+    mf = LinearMean(3)
+
+    with pytest.raises(IndexError):
+        mf.mean_f(x, np.zeros(0))
+
+def test_MeanSum(x, oneparams, dx):
     "test the MeanSum function"
 
-    mf = FixedMean(3.) + LinearMean()
+    n_params = 1
+    index = 0
 
-    params = np.ones(3)
+    mf = Coefficient() + LinearMean(index)
 
-    assert mf.get_n_params(x) == 3
+    assert mf.get_n_params(x) == n_params
 
-    assert_allclose(mf.mean_f(x, params), [9., 18.])
-    assert_allclose(mf.mean_deriv(x, params), np.transpose(x))
-    assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
-    assert_allclose(mf.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
+    inputderiv_exp = np.zeros((x.shape[1], x.shape[0]))
+    inputderiv_exp[index] = 1.
 
-    deriv_fd = np.zeros((3, 2))
-    deriv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([dx, 0., 0.])))/dx
-    deriv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., dx, 0.])))/dx
-    deriv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., 0., dx])))/dx
+    assert_allclose(mf.mean_f(x, oneparams), 1. + x[:,index])
+    assert_allclose(mf.mean_deriv(x, oneparams), np.ones((n_params, x.shape[0])))
+    assert_allclose(mf.mean_hessian(x, oneparams), np.zeros((n_params, n_params, x.shape[0])))
+    assert_allclose(mf.mean_inputderiv(x, oneparams), inputderiv_exp)
 
-    assert_allclose(mf.mean_deriv(x, params), deriv_fd)
+    deriv_fd = np.zeros((n_params, x.shape[0]))
+    for i in range(n_params):
+        dx_array = np.zeros(n_params)
+        dx_array[i] = dx
+        deriv_fd[i] = (mf.mean_f(x, oneparams) - mf.mean_f(x, oneparams - dx_array))/dx
 
-    inputderiv_fd = np.zeros((3, 2))
-    inputderiv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([dx, 0., 0.]), params))/dx
-    inputderiv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., dx, 0.]), params))/dx
-    inputderiv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., 0., dx]), params))/dx
+    assert_allclose(mf.mean_deriv(x, oneparams), deriv_fd)
 
-    assert_allclose(mf.mean_inputderiv(x, params), inputderiv_fd)
+    hess_fd = np.zeros((n_params, n_params, x.shape[0]))
+    for i in range(n_params):
+        for j in range(n_params):
+            dx_array = np.zeros(n_params)
+            dx_array[j] = dx
+            hess_fd[i,j] = (mf.mean_deriv(x, oneparams)[i] -
+                            mf.mean_deriv(x, oneparams - dx_array)[i])/dx
 
-    mf2 = ConstantMean() + LinearMean()
+    assert_allclose(mf.mean_hessian(x, oneparams), hess_fd)
 
-    params = np.ones(4)
+    D = x.shape[1]
 
-    assert mf2.get_n_params(x) == 4
+    inputderiv_fd = np.zeros((D, x.shape[0]))
+    for i in range(D):
+        dx_array = np.zeros(D)
+        dx_array[i] = dx
+        inputderiv_fd[i] = (mf.mean_f(x, oneparams) - mf.mean_f(x - dx_array, oneparams))/dx
 
-    assert_allclose(mf2.mean_f(x, params), [7., 16.])
-    assert_allclose(mf2.mean_deriv(x, params), np.vstack((np.ones((2,)), np.transpose(x))))
-    assert_allclose(mf2.mean_hessian(x, params), np.zeros((4, 4, x.shape[0])))
-    assert_allclose(mf2.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
+    assert_allclose(mf.mean_inputderiv(x, oneparams), inputderiv_fd)
 
-    deriv_fd = np.zeros((4, 2))
-    deriv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([dx, 0., 0., 0.])))/dx
-    deriv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., dx, 0., 0.])))/dx
-    deriv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., dx, 0.])))/dx
-    deriv_fd[3] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., dx])))/dx
-
-    assert_allclose(mf2.mean_deriv(x, params), deriv_fd)
-
-    inputderiv_fd = np.zeros((3, 2))
-    inputderiv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([dx, 0., 0.]), params))/dx
-    inputderiv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., dx, 0.]), params))/dx
-    inputderiv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., 0., dx]), params))/dx
-
-    assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_fd)
-
-def test_MeanProduct(x, dx):
+def test_MeanProduct(x, oneparams, dx):
     "test the MeanProduct function"
 
-    mf = FixedMean(3.)*LinearMean()
+    n_params = 1
+    index = 0
 
-    params = np.ones(3)
+    mf = Coefficient()*LinearMean(index)
 
-    assert mf.get_n_params(x) == 3
+    assert mf.get_n_params(x) == n_params
 
-    assert_allclose(mf.mean_f(x, params), [18., 45.])
-    assert_allclose(mf.mean_deriv(x, params), 3.*np.transpose(x))
-    assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
-    assert_allclose(mf.mean_inputderiv(x, params), 3.*np.ones((x.shape[1], x.shape[0])))
+    inputderiv_exp = np.zeros((x.shape[1], x.shape[0]))
+    inputderiv_exp[index] = np.broadcast_to(oneparams, (x.shape[0],))
 
-    deriv_fd = np.zeros((3, 2))
-    deriv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([dx, 0., 0.])))/dx
-    deriv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., dx, 0.])))/dx
-    deriv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., 0., dx])))/dx
+    assert_allclose(mf.mean_f(x, oneparams), 1.*x[:,index])
+    assert_allclose(mf.mean_deriv(x, oneparams), np.broadcast_to(x[:,index], (n_params, x.shape[0])))
+    assert_allclose(mf.mean_hessian(x, oneparams), np.zeros((n_params, n_params, x.shape[0])))
+    assert_allclose(mf.mean_inputderiv(x, oneparams), inputderiv_exp)
+
+    deriv_fd = np.zeros((n_params, x.shape[0]))
+    for i in range(n_params):
+        dx_array = np.zeros(n_params)
+        dx_array[i] = dx
+        deriv_fd[i] = (mf.mean_f(x, oneparams) - mf.mean_f(x, oneparams - dx_array))/dx
+
+    assert_allclose(mf.mean_deriv(x, oneparams), deriv_fd)
+
+    hess_fd = np.zeros((n_params, n_params, x.shape[0]))
+    for i in range(n_params):
+        for j in range(n_params):
+            dx_array = np.zeros(n_params)
+            dx_array[j] = dx
+            hess_fd[i,j] = (mf.mean_deriv(x, oneparams)[i] -
+                            mf.mean_deriv(x, oneparams - dx_array)[i])/dx
+
+    assert_allclose(mf.mean_hessian(x, oneparams), hess_fd)
+
+    D = x.shape[1]
+
+    inputderiv_fd = np.zeros((D, x.shape[0]))
+    for i in range(D):
+        dx_array = np.zeros(D)
+        dx_array[i] = dx
+        inputderiv_fd[i] = (mf.mean_f(x, oneparams) - mf.mean_f(x - dx_array, oneparams))/dx
+
+    assert_allclose(mf.mean_inputderiv(x, oneparams), inputderiv_fd)
+
+def test_MeanSum_MeanProduct_combination(x, params, dx):
+    "test a more complicated combination of sums and products"
+
+    n_params = 3
+    index1 = 0
+    index2 = 1
+    index3 = 2
+
+    mf = (Coefficient() + Coefficient()*LinearMean(index1) +
+          Coefficient()*LinearMean(index2)*LinearMean(index3))
+
+    assert mf.get_n_params(x) == n_params
+
+    deriv_exp = np.zeros((n_params, x.shape[0]))
+    deriv_exp[0] = 1.
+    deriv_exp[1] = x[:,index1]
+    deriv_exp[2] = x[:,index2]*x[:,index3]
+
+    inputderiv_exp = np.zeros((x.shape[1], x.shape[0]))
+    inputderiv_exp[0,:] = params[1]
+    inputderiv_exp[1,:] = params[2]*x[:,index3]
+    inputderiv_exp[2,:] = params[2]*x[:,index2]
+
+    assert_allclose(mf.mean_f(x, params), params[0] + params[1]*x[:,index1]
+                                                    + params[2]*x[:,index2]*x[:,index3])
+    assert_allclose(mf.mean_deriv(x, params), deriv_exp)
+    assert_allclose(mf.mean_hessian(x, params), np.zeros((n_params, n_params, x.shape[0])))
+    assert_allclose(mf.mean_inputderiv(x, params), inputderiv_exp)
+
+    deriv_fd = np.zeros((n_params, x.shape[0]))
+    for i in range(n_params):
+        dx_array = np.zeros(n_params)
+        dx_array[i] = dx
+        deriv_fd[i] = (mf.mean_f(x, params) - mf.mean_f(x, params - dx_array))/dx
 
     assert_allclose(mf.mean_deriv(x, params), deriv_fd)
 
-    inputderiv_fd = np.zeros((3, 2))
-    inputderiv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([dx, 0., 0.]), params))/dx
-    inputderiv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., dx, 0.]), params))/dx
-    inputderiv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., 0., dx]), params))/dx
+    hess_fd = np.zeros((n_params, n_params, x.shape[0]))
+    for i in range(n_params):
+        for j in range(n_params):
+            dx_array = np.zeros(n_params)
+            dx_array[j] = dx
+            hess_fd[i,j] = (mf.mean_deriv(x, params)[i] -
+                            mf.mean_deriv(x, params - dx_array)[i])/dx
+
+    assert_allclose(mf.mean_hessian(x, params), hess_fd)
+
+    D = x.shape[1]
+
+    inputderiv_fd = np.zeros((D, x.shape[0]))
+    for i in range(D):
+        dx_array = np.zeros(D)
+        dx_array[i] = dx
+        inputderiv_fd[i] = (mf.mean_f(x, params) - mf.mean_f(x - dx_array, params))/dx
 
     assert_allclose(mf.mean_inputderiv(x, params), inputderiv_fd)
 
-    mf2 = LinearMean()*LinearMean()
+def test_CompositeMean(x, params, dx):
+    "test the composite mean function"
 
-    params = np.ones(6)
+    mf1 = LinearMean(0)*LinearMean(1)
+    mf2 = Coefficient() + Coefficient()*LinearMean(0) + Coefficient()*LinearMean(0)*LinearMean(0)
 
-    assert mf2.get_n_params(x) == 6
+    mf = mf2(mf1)
 
-    hess_expected = np.zeros((6, 6, 2))
-    hess_expected[3:6, 0:3, 0] = np.array([[1., 2., 3.], [2., 4., 6.], [3., 6., 9.]])
-    hess_expected[0:3, 3:6, 0] = np.transpose([[1., 2., 3.], [2., 4., 6.], [3., 6., 9.]])
-    hess_expected[3:6, 0:3, 1] = np.array([[16., 20., 24.], [20., 25., 30.], [24., 30., 36.]])
-    hess_expected[0:3, 3:6, 1] = np.transpose([[16., 20., 24.], [20., 25., 30.], [24., 30., 36.]])
+    n_params = 3
 
-    inputderiv_expected = np.zeros((3, 2))
-    inputderiv_expected[:, 0] = 12.
-    inputderiv_expected[:, 1] = 30.
+    assert mf.get_n_params(x) == n_params
 
-    assert_allclose(mf2.mean_f(x, params), [36., 225.])
-    assert_allclose(mf2.mean_deriv(x, params), np.vstack((np.transpose(x), np.transpose(x)))*np.broadcast_to([6., 15.], (6, 2)))
-    assert_allclose(mf2.mean_hessian(x, params), hess_expected)
-    assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_expected)
+    deriv_exp = np.zeros((n_params, x.shape[0]))
+    deriv_exp[0,:] = 1.
+    deriv_exp[1,:] = x[:,0]*x[:,1]
+    deriv_exp[2,:] = x[:,0]**2*x[:,1]**2
 
-    deriv_fd = np.zeros((6, 2))
-    deriv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([dx, 0., 0., 0., 0., 0.])))/dx
-    deriv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., dx, 0., 0., 0., 0.])))/dx
-    deriv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., dx, 0., 0., 0.])))/dx
-    deriv_fd[3] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., dx, 0., 0.])))/dx
-    deriv_fd[4] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., 0., dx, 0.])))/dx
-    deriv_fd[5] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., 0., 0., dx])))/dx
+    inputderiv_exp = np.zeros((x.shape[1], x.shape[0]))
+    inputderiv_exp[0] = params[1]*x[:,1] + 2.*params[2]*x[:,0]*x[:,1]**2
+    inputderiv_exp[1] = params[1]*x[:,0] + 2.*params[2]*x[:,0]**2*x[:,1]
 
-    assert_allclose(mf2.mean_deriv(x, params), deriv_fd)
+    assert_allclose(mf.mean_f(x, params), params[0] + params[1]*x[:,0]*x[:,1]
+                                                    + params[2]*x[:,0]**2*x[:,1]**2)
+    assert_allclose(mf.mean_deriv(x, params), deriv_exp)
+    assert_allclose(mf.mean_inputderiv(x, params), inputderiv_exp)
 
-    inputderiv_fd = np.zeros((3, 2))
-    inputderiv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([dx, 0., 0.]), params))/dx
-    inputderiv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., dx, 0.]), params))/dx
-    inputderiv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., 0., dx]), params))/dx
-
-    assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_fd)
-
-    hess_fd = np.zeros((6, 6, 2))
-    hess_fd[:, 0] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([dx, 0., 0., 0., 0., 0.])))/dx
-    hess_fd[:, 1] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., dx, 0., 0., 0., 0.])))/dx
-    hess_fd[:, 2] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., dx, 0., 0., 0.])))/dx
-    hess_fd[:, 3] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., 0., dx, 0., 0.])))/dx
-    hess_fd[:, 4] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., 0., 0., dx, 0.])))/dx
-    hess_fd[:, 5] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., 0., 0., 0., dx])))/dx
-
-    assert_allclose(mf2.mean_hessian(x, params), hess_fd)
+    with pytest.raises(NotImplementedError):
+        mf.mean_hessian(x, params)
 
 def test_PolynomialMean(x, dx):
     "test the polynomial mean function"
 
-    poly_mean = PolynomialMean(2)
+    degree = 2
 
-    with pytest.raises(AssertionError):
-        PolynomialMean(-1)
+    poly_mean = PolynomialMean(degree)
+    n_params = 1 + x.shape[1]*degree
 
-    params = np.arange(1., 8.)
+    assert poly_mean.degree == degree
+    assert poly_mean.get_n_params(x) == n_params
+
+    params = np.arange(1., 1.+float(n_params))
 
     mean_expected = np.array([(params[0] + params[1]*x[0, 0] + params[2]*x[0, 1] + params[3]*x[0, 2]
                                          + params[4]*x[0, 0]**2 + params[5]*x[0, 1]**2 + params[6]*x[0, 2]**2),
@@ -285,7 +412,7 @@ def test_PolynomialMean(x, dx):
                                          + params[4]*x[1, 0]**2 + params[5]*x[1, 1]**2 + params[6]*x[1, 2]**2)])
     deriv_expected = np.array([[1., 1.], x[:, 0], x[:, 1], x[:, 2],
                                          x[:, 0]**2, x[:, 1]**2, x[:, 2]**2])
-    hess_expected = np.zeros((7, 7, 2))
+    hess_expected = np.zeros((n_params, n_params, 2))
     inputderiv_expected = np.array([[params[1] + 2.*params[4]*x[0,0], params[1] + 2.*params[4]*x[1,0]],
                                     [params[2] + 2.*params[5]*x[0,1], params[2] + 2.*params[5]*x[1,1]],
                                     [params[3] + 2.*params[6]*x[0,2], params[3] + 2.*params[6]*x[1,2]]])
@@ -295,20 +422,45 @@ def test_PolynomialMean(x, dx):
     assert_allclose(poly_mean.mean_hessian(x, params), hess_expected)
     assert_allclose(poly_mean.mean_inputderiv(x, params), inputderiv_expected)
 
-    deriv_fd = np.zeros((7, 2))
-    deriv_fd[0] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([dx, 0., 0., 0., 0., 0., 0.])))/dx
-    deriv_fd[1] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., dx, 0., 0., 0., 0., 0.])))/dx
-    deriv_fd[2] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., dx, 0., 0., 0., 0.])))/dx
-    deriv_fd[3] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., dx, 0., 0., 0.])))/dx
-    deriv_fd[4] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., 0., dx, 0., 0.])))/dx
-    deriv_fd[5] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., 0., 0., dx, 0.])))/dx
-    deriv_fd[6] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., 0., 0., 0., dx])))/dx
+    deriv_fd = np.zeros((n_params, 2))
+    for i in range(n_params):
+        dx_array = np.zeros(n_params)
+        dx_array[i] = dx
+        deriv_fd[i] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - dx_array))/dx
 
     assert_allclose(poly_mean.mean_deriv(x, params), deriv_fd)
 
-    inputderiv_fd = np.zeros((3, 2))
-    inputderiv_fd[0] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - np.array([dx, 0., 0.]), params))/dx
-    inputderiv_fd[1] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - np.array([0., dx, 0.]), params))/dx
-    inputderiv_fd[2] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - np.array([0., 0., dx]), params))/dx
+    hess_fd = np.zeros((n_params, n_params, 2))
+    for i in range(n_params):
+        for j in range(n_params):
+            dx_array = np.zeros(n_params)
+            dx_array[j] = dx
+            hess_fd[i, j] = (poly_mean.mean_deriv(x, params)[i] - poly_mean.mean_deriv(x, params - dx_array)[i])/dx
+
+    assert_allclose(poly_mean.mean_hessian(x, params), hess_fd)
+
+    D = 3
+
+    inputderiv_fd = np.zeros((D, 2))
+    for i in range(D):
+        dx_array = np.zeros(D)
+        dx_array[i] = dx
+        inputderiv_fd[i] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - dx_array, params))/dx
 
     assert_allclose(poly_mean.mean_inputderiv(x, params), inputderiv_fd, atol=1.e-5)
+
+def test_PolynomialMean_failures(x):
+    "test situations where PolynomialMean should raise an error"
+
+    with pytest.raises(AssertionError):
+        PolynomialMean(-1)
+
+    degree = 2
+
+    poly_mean = PolynomialMean(degree)
+
+    with pytest.raises(AssertionError):
+        poly_mean._check_inputs(x, np.ones(4))
+
+    with pytest.raises(AssertionError):
+        poly_mean._check_inputs(np.ones((2, 3, 2)), np.ones(7))

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -162,6 +162,12 @@ def test_ConstantMean(x, zeroparams, val):
     assert_allclose(constant_mean.mean_hessian(x, zeroparams), np.zeros((0, 0, x.shape[0])))
     assert_allclose(constant_mean.mean_inputderiv(x, zeroparams), np.zeros((x.shape[1], x.shape[0])))
 
+def test_ConstantMean_failures():
+    "test situation where ConstantMean should fail"
+
+    with pytest.raises(TypeError):
+        ConstantMean("a")
+
 @pytest.mark.parametrize("index", [0, 1])
 def test_LinearMean(x, zeroparams, dx, index):
     "test the linear mean function"

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -16,6 +16,10 @@ def x():
 def params():
     return np.array([1., 2., 4.])
 
+@pytest.fixture
+def dx():
+    return 1.e-6
+
 def test_MeanFunction(mf, x, params):
     "test composition of mean functions"
 
@@ -108,7 +112,7 @@ def test_ConstantMean(x):
     assert_allclose(constant_mean.mean_hessian(x, params), np.zeros((1, 1, x.shape[0])))
     assert_allclose(constant_mean.mean_inputderiv(x, params), np.zeros((x.shape[1], x.shape[0])))
 
-def test_LinearMean(x, params):
+def test_LinearMean(x, params, dx):
     "test the linear mean function"
 
     linear_mean = LinearMean()
@@ -121,7 +125,6 @@ def test_LinearMean(x, params):
     assert_allclose(linear_mean.mean_inputderiv(x, params),
                     np.broadcast_to(np.reshape(params, (-1, 1)), (x.shape[1], x.shape[0])))
 
-    dx = 1.e-6
     deriv_fd = np.zeros((3, 2))
     deriv_fd[0] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([dx, 0., 0.])))/dx
     deriv_fd[1] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([0., dx, 0.])))/dx
@@ -136,7 +139,7 @@ def test_LinearMean(x, params):
 
     assert_allclose(linear_mean.mean_inputderiv(x, params), inputderiv_fd)
 
-def test_MeanSum(x):
+def test_MeanSum(x, dx):
     "test the MeanSum function"
 
     mf = FixedMean(3.) + LinearMean()
@@ -150,7 +153,6 @@ def test_MeanSum(x):
     assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
     assert_allclose(mf.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
 
-    dx = 1.e-6
     deriv_fd = np.zeros((3, 2))
     deriv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([dx, 0., 0.])))/dx
     deriv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., dx, 0.])))/dx
@@ -191,7 +193,7 @@ def test_MeanSum(x):
 
     assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_fd)
 
-def test_MeanProduct(x):
+def test_MeanProduct(x, dx):
     "test the MeanProduct function"
 
     mf = FixedMean(3.)*LinearMean()
@@ -205,7 +207,6 @@ def test_MeanProduct(x):
     assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
     assert_allclose(mf.mean_inputderiv(x, params), 3.*np.ones((x.shape[1], x.shape[0])))
 
-    dx = 1.e-6
     deriv_fd = np.zeros((3, 2))
     deriv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([dx, 0., 0.])))/dx
     deriv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., dx, 0.])))/dx
@@ -241,7 +242,6 @@ def test_MeanProduct(x):
     assert_allclose(mf2.mean_hessian(x, params), hess_expected)
     assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_expected)
 
-    dx = 1.e-6
     deriv_fd = np.zeros((6, 2))
     deriv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([dx, 0., 0., 0., 0., 0.])))/dx
     deriv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., dx, 0., 0., 0., 0.])))/dx
@@ -269,7 +269,7 @@ def test_MeanProduct(x):
 
     assert_allclose(mf2.mean_hessian(x, params), hess_fd)
 
-def test_PolynomialMean(x):
+def test_PolynomialMean(x, dx):
     "test the polynomial mean function"
 
     poly_mean = PolynomialMean(2)
@@ -295,7 +295,6 @@ def test_PolynomialMean(x):
     assert_allclose(poly_mean.mean_hessian(x, params), hess_expected)
     assert_allclose(poly_mean.mean_inputderiv(x, params), inputderiv_expected)
 
-    dx = 1.e-6
     deriv_fd = np.zeros((7, 2))
     deriv_fd[0] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([dx, 0., 0., 0., 0., 0., 0.])))/dx
     deriv_fd[1] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., dx, 0., 0., 0., 0., 0.])))/dx

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -121,6 +121,21 @@ def test_LinearMean(x, params):
     assert_allclose(linear_mean.mean_inputderiv(x, params),
                     np.broadcast_to(np.reshape(params, (-1, 1)), (x.shape[1], x.shape[0])))
 
+    dx = 1.e-6
+    deriv_fd = np.zeros((3, 2))
+    deriv_fd[0] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([dx, 0., 0.])))/dx
+    deriv_fd[1] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([0., dx, 0.])))/dx
+    deriv_fd[2] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x, params - np.array([0., 0., dx])))/dx
+
+    assert_allclose(linear_mean.mean_deriv(x, params), deriv_fd)
+
+    inputderiv_fd = np.zeros((3, 2))
+    inputderiv_fd[0] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x - np.array([dx, 0., 0.]), params))/dx
+    inputderiv_fd[1] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x - np.array([0., dx, 0.]), params))/dx
+    inputderiv_fd[2] = (linear_mean.mean_f(x, params) - linear_mean.mean_f(x - np.array([0., 0., dx]), params))/dx
+
+    assert_allclose(linear_mean.mean_inputderiv(x, params), inputderiv_fd)
+
 def test_MeanSum(x):
     "test the MeanSum function"
 
@@ -135,6 +150,21 @@ def test_MeanSum(x):
     assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
     assert_allclose(mf.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
 
+    dx = 1.e-6
+    deriv_fd = np.zeros((3, 2))
+    deriv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([dx, 0., 0.])))/dx
+    deriv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., dx, 0.])))/dx
+    deriv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., 0., dx])))/dx
+
+    assert_allclose(mf.mean_deriv(x, params), deriv_fd)
+
+    inputderiv_fd = np.zeros((3, 2))
+    inputderiv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([dx, 0., 0.]), params))/dx
+    inputderiv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., dx, 0.]), params))/dx
+    inputderiv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., 0., dx]), params))/dx
+
+    assert_allclose(mf.mean_inputderiv(x, params), inputderiv_fd)
+
     mf2 = ConstantMean() + LinearMean()
 
     params = np.ones(4)
@@ -145,6 +175,21 @@ def test_MeanSum(x):
     assert_allclose(mf2.mean_deriv(x, params), np.vstack((np.ones((2,)), np.transpose(x))))
     assert_allclose(mf2.mean_hessian(x, params), np.zeros((4, 4, x.shape[0])))
     assert_allclose(mf2.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
+
+    deriv_fd = np.zeros((4, 2))
+    deriv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([dx, 0., 0., 0.])))/dx
+    deriv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., dx, 0., 0.])))/dx
+    deriv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., dx, 0.])))/dx
+    deriv_fd[3] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., dx])))/dx
+
+    assert_allclose(mf2.mean_deriv(x, params), deriv_fd)
+
+    inputderiv_fd = np.zeros((3, 2))
+    inputderiv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([dx, 0., 0.]), params))/dx
+    inputderiv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., dx, 0.]), params))/dx
+    inputderiv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., 0., dx]), params))/dx
+
+    assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_fd)
 
 def test_MeanProduct(x):
     "test the MeanProduct function"
@@ -159,6 +204,21 @@ def test_MeanProduct(x):
     assert_allclose(mf.mean_deriv(x, params), 3.*np.transpose(x))
     assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
     assert_allclose(mf.mean_inputderiv(x, params), 3.*np.ones((x.shape[1], x.shape[0])))
+
+    dx = 1.e-6
+    deriv_fd = np.zeros((3, 2))
+    deriv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([dx, 0., 0.])))/dx
+    deriv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., dx, 0.])))/dx
+    deriv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x, params - np.array([0., 0., dx])))/dx
+
+    assert_allclose(mf.mean_deriv(x, params), deriv_fd)
+
+    inputderiv_fd = np.zeros((3, 2))
+    inputderiv_fd[0] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([dx, 0., 0.]), params))/dx
+    inputderiv_fd[1] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., dx, 0.]), params))/dx
+    inputderiv_fd[2] = (mf.mean_f(x, params) - mf.mean_f(x - np.array([0., 0., dx]), params))/dx
+
+    assert_allclose(mf.mean_inputderiv(x, params), inputderiv_fd)
 
     mf2 = LinearMean()*LinearMean()
 
@@ -180,6 +240,34 @@ def test_MeanProduct(x):
     assert_allclose(mf2.mean_deriv(x, params), np.vstack((np.transpose(x), np.transpose(x)))*np.broadcast_to([6., 15.], (6, 2)))
     assert_allclose(mf2.mean_hessian(x, params), hess_expected)
     assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_expected)
+
+    dx = 1.e-6
+    deriv_fd = np.zeros((6, 2))
+    deriv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([dx, 0., 0., 0., 0., 0.])))/dx
+    deriv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., dx, 0., 0., 0., 0.])))/dx
+    deriv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., dx, 0., 0., 0.])))/dx
+    deriv_fd[3] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., dx, 0., 0.])))/dx
+    deriv_fd[4] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., 0., dx, 0.])))/dx
+    deriv_fd[5] = (mf2.mean_f(x, params) - mf2.mean_f(x, params - np.array([0., 0., 0., 0., 0., dx])))/dx
+
+    assert_allclose(mf2.mean_deriv(x, params), deriv_fd)
+
+    inputderiv_fd = np.zeros((3, 2))
+    inputderiv_fd[0] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([dx, 0., 0.]), params))/dx
+    inputderiv_fd[1] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., dx, 0.]), params))/dx
+    inputderiv_fd[2] = (mf2.mean_f(x, params) - mf2.mean_f(x - np.array([0., 0., dx]), params))/dx
+
+    assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_fd)
+
+    hess_fd = np.zeros((6, 6, 2))
+    hess_fd[:, 0] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([dx, 0., 0., 0., 0., 0.])))/dx
+    hess_fd[:, 1] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., dx, 0., 0., 0., 0.])))/dx
+    hess_fd[:, 2] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., dx, 0., 0., 0.])))/dx
+    hess_fd[:, 3] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., 0., dx, 0., 0.])))/dx
+    hess_fd[:, 4] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., 0., 0., dx, 0.])))/dx
+    hess_fd[:, 5] = (mf2.mean_deriv(x, params) - mf2.mean_deriv(x, params - np.array([0., 0., 0., 0., 0., dx])))/dx
+
+    assert_allclose(mf2.mean_hessian(x, params), hess_fd)
 
 def test_PolynomialMean(x):
     "test the polynomial mean function"
@@ -206,3 +294,22 @@ def test_PolynomialMean(x):
     assert_allclose(poly_mean.mean_deriv(x, params), deriv_expected)
     assert_allclose(poly_mean.mean_hessian(x, params), hess_expected)
     assert_allclose(poly_mean.mean_inputderiv(x, params), inputderiv_expected)
+
+    dx = 1.e-6
+    deriv_fd = np.zeros((7, 2))
+    deriv_fd[0] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([dx, 0., 0., 0., 0., 0., 0.])))/dx
+    deriv_fd[1] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., dx, 0., 0., 0., 0., 0.])))/dx
+    deriv_fd[2] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., dx, 0., 0., 0., 0.])))/dx
+    deriv_fd[3] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., dx, 0., 0., 0.])))/dx
+    deriv_fd[4] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., 0., dx, 0., 0.])))/dx
+    deriv_fd[5] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., 0., 0., dx, 0.])))/dx
+    deriv_fd[6] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x, params - np.array([0., 0., 0., 0., 0., 0., dx])))/dx
+
+    assert_allclose(poly_mean.mean_deriv(x, params), deriv_fd)
+
+    inputderiv_fd = np.zeros((3, 2))
+    inputderiv_fd[0] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - np.array([dx, 0., 0.]), params))/dx
+    inputderiv_fd[1] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - np.array([0., dx, 0.]), params))/dx
+    inputderiv_fd[2] = (poly_mean.mean_f(x, params) - poly_mean.mean_f(x - np.array([0., 0., dx]), params))/dx
+
+    assert_allclose(poly_mean.mean_inputderiv(x, params), inputderiv_fd, atol=1.e-5)

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -1,0 +1,181 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from ..MeanFunction import MeanFunction, MeanSum, MeanProduct, FixedMean, ConstantMean, LinearMean
+
+@pytest.fixture
+def mf():
+    return MeanFunction()
+
+@pytest.fixture
+def x():
+    return np.array([[1., 2., 3.], [4., 5., 6.]])
+
+@pytest.fixture
+def params():
+    return np.array([1., 2., 4.])
+
+def test_MeanFunction(mf, x, params):
+    "test composition of mean functions"
+
+    mf2 = mf + mf
+
+    assert isinstance(mf2, MeanSum)
+
+    mf3 = 5. + mf
+
+    assert isinstance(mf3, MeanSum)
+    assert isinstance(mf3.f1, FixedMean)
+
+    mf4 = mf + 3.
+
+    assert isinstance(mf4, MeanSum)
+    assert isinstance(mf4.f2, FixedMean)
+
+    mf5 = mf*mf
+
+    assert isinstance(mf5, MeanProduct)
+
+    mf6 = 3.*mf
+
+    assert isinstance(mf6, MeanProduct)
+    assert isinstance(mf6.f1, FixedMean)
+
+    mf7 = mf*3.
+
+    assert isinstance(mf7, MeanProduct)
+    assert isinstance(mf7.f2, FixedMean)
+
+def test_MeanFunction_failures(mf, x, params):
+    "test situations of MeanFunction where an exception should be raised"
+
+    with pytest.raises(NotImplementedError):
+        mf.get_n_params(x)
+
+    with pytest.raises(NotImplementedError):
+        mf.mean_f(x, params)
+
+    with pytest.raises(NotImplementedError):
+        mf.mean_deriv(x, params)
+
+    with pytest.raises(NotImplementedError):
+        mf.mean_hessian(x, params)
+
+    with pytest.raises(NotImplementedError):
+        mf.mean_inputderiv(x, params)
+
+    with pytest.raises(TypeError):
+        "3" + mf
+
+    with pytest.raises(TypeError):
+        mf + "3"
+
+    with pytest.raises(TypeError):
+        mf*"3"
+
+    with pytest.raises(TypeError):
+        "3"*mf
+
+def test_FixedMean(x):
+    "test the FixedMean function"
+
+    params = np.zeros(0)
+
+    f = lambda x: np.ones(x.shape[0])
+    deriv = lambda x: np.zeros((x.shape[1], x.shape[0]))
+    fixed_mean = FixedMean(f, deriv)
+
+    assert fixed_mean.get_n_params(x) == 0
+
+    assert_allclose(fixed_mean.mean_f(x, params), np.ones(x.shape[0]))
+    assert_allclose(fixed_mean.mean_f(np.array([1., 2., 3.]), params), np.ones(3))
+    assert_allclose(fixed_mean.mean_deriv(x, params), np.zeros((0, x.shape[0])))
+    assert_allclose(fixed_mean.mean_hessian(x, params), np.zeros((0, 0, x.shape[0])))
+    assert_allclose(fixed_mean.mean_inputderiv(x, params), np.zeros((x.shape[1], x.shape[0])))
+
+def test_ConstantMean(x):
+    "test the constant mean function"
+
+    params = np.ones(1)
+
+    constant_mean = ConstantMean()
+
+    assert constant_mean.get_n_params(x) == 1
+
+    assert_allclose(constant_mean.mean_f(x, params), np.broadcast_to(1., x.shape[0]))
+    assert_allclose(constant_mean.mean_deriv(x, params), np.ones((1, x.shape[0])))
+    assert_allclose(constant_mean.mean_hessian(x, params), np.zeros((1, 1, x.shape[0])))
+    assert_allclose(constant_mean.mean_inputderiv(x, params), np.zeros((x.shape[1], x.shape[0])))
+
+def test_LinearMean(x, params):
+    "test the linear mean function"
+
+    linear_mean = LinearMean()
+
+    assert linear_mean.get_n_params(x) == 3
+
+    assert_allclose(linear_mean.mean_f(x, params), np.sum(x*params, axis=1))
+    assert_allclose(linear_mean.mean_deriv(x, params), np.transpose(x))
+    assert_allclose(linear_mean.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
+    assert_allclose(linear_mean.mean_inputderiv(x, params),
+                    np.broadcast_to(np.reshape(params, (-1, 1)), (x.shape[1], x.shape[0])))
+
+def test_MeanSum(x):
+    "test the MeanSum function"
+
+    mf = FixedMean(3.) + LinearMean()
+
+    params = np.ones(3)
+
+    assert mf.get_n_params(x) == 3
+
+    assert_allclose(mf.mean_f(x, params), [9., 18.])
+    assert_allclose(mf.mean_deriv(x, params), np.transpose(x))
+    assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
+    assert_allclose(mf.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
+
+    mf2 = ConstantMean() + LinearMean()
+
+    params = np.ones(4)
+
+    assert mf2.get_n_params(x) == 4
+
+    assert_allclose(mf2.mean_f(x, params), [7., 16.])
+    assert_allclose(mf2.mean_deriv(x, params), np.vstack((np.ones((2,)), np.transpose(x))))
+    assert_allclose(mf2.mean_hessian(x, params), np.zeros((4, 4, x.shape[0])))
+    assert_allclose(mf2.mean_inputderiv(x, params), np.ones((x.shape[1], x.shape[0])))
+
+def test_MeanProduct(x):
+    "test the MeanProduct function"
+
+    mf = FixedMean(3.)*LinearMean()
+
+    params = np.ones(3)
+
+    assert mf.get_n_params(x) == 3
+
+    assert_allclose(mf.mean_f(x, params), [18., 45.])
+    assert_allclose(mf.mean_deriv(x, params), 3.*np.transpose(x))
+    assert_allclose(mf.mean_hessian(x, params), np.zeros((3, 3, x.shape[0])))
+    assert_allclose(mf.mean_inputderiv(x, params), 3.*np.ones((x.shape[1], x.shape[0])))
+
+    mf2 = LinearMean()*LinearMean()
+
+    params = np.ones(6)
+
+    assert mf2.get_n_params(x) == 6
+
+    hess_expected = np.zeros((6, 6, 2))
+    hess_expected[3:6, 0:3, 0] = np.array([[1., 2., 3.], [2., 4., 6.], [3., 6., 9.]])
+    hess_expected[0:3, 3:6, 0] = np.transpose([[1., 2., 3.], [2., 4., 6.], [3., 6., 9.]])
+    hess_expected[3:6, 0:3, 1] = np.array([[16., 20., 24.], [20., 25., 30.], [24., 30., 36.]])
+    hess_expected[0:3, 3:6, 1] = np.transpose([[16., 20., 24.], [20., 25., 30.], [24., 30., 36.]])
+
+    inputderiv_expected = np.zeros((3, 2))
+    inputderiv_expected[:, 0] = 12.
+    inputderiv_expected[:, 1] = 30.
+
+    assert_allclose(mf2.mean_f(x, params), [36., 225.])
+    assert_allclose(mf2.mean_deriv(x, params), np.vstack((np.transpose(x), np.transpose(x)))*np.broadcast_to([6., 15.], (6, 2)))
+    assert_allclose(mf2.mean_hessian(x, params), hess_expected)
+    assert_allclose(mf2.mean_inputderiv(x, params), inputderiv_expected)

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -399,6 +399,18 @@ def test_CompositeMean(x, params, dx):
     with pytest.raises(NotImplementedError):
         mf.mean_hessian(x, params)
 
+    mf3 = Coefficient() + Coefficient()*LinearMean(1) + Coefficient()*LinearMean(0)
+    mf4 = mf3(mf1)
+
+    with pytest.raises(IndexError):
+        mf4.mean_f(x, params)
+
+    with pytest.raises(IndexError):
+        mf4.mean_deriv(x, params)
+
+    with pytest.raises(IndexError):
+        mf4.mean_inputderiv(x, params)
+
 def test_PolynomialMean(x, dx):
     "test the polynomial mean function"
 

--- a/mogp_emulator/tests/test_MeanFunction.py
+++ b/mogp_emulator/tests/test_MeanFunction.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from ..MeanFunction import MeanFunction, MeanSum, MeanProduct, FixedMean, ConstantMean, LinearMean
-from ..MeanFunction import Coefficient, PolynomialMean, MeanComposite, MeanPower
+from ..MeanFunction import MeanFunction, MeanBase, MeanSum, MeanProduct, FixedMean, ConstantMean
+from ..MeanFunction import LinearMean, Coefficient, PolynomialMean, MeanComposite, MeanPower
 from ..MeanFunction import fixed_f, fixed_inputderiv, one, const_f, const_deriv
 
 @pytest.fixture
 def mf():
-    return MeanFunction()
+    return MeanBase()
 
 @pytest.fixture
 def x():
@@ -29,7 +29,7 @@ def oneparams():
 def dx():
     return 1.e-6
 
-def test_MeanFunction(mf, x, params):
+def test_MeanBase(mf, x, params):
     "test composition of mean functions"
 
     mf2 = mf + mf
@@ -78,8 +78,8 @@ def test_MeanFunction(mf, x, params):
 
     assert isinstance(mf11, MeanComposite)
 
-def test_MeanFunction_failures(mf, x, params):
-    "test situations of MeanFunction where an exception should be raised"
+def test_MeanBase_failures(mf, x, params):
+    "test situations of MeanBase where an exception should be raised"
 
     with pytest.raises(NotImplementedError):
         mf.get_n_params(x)
@@ -123,28 +123,28 @@ def test_MeanFunction_failures(mf, x, params):
     with pytest.raises(TypeError):
         mf(3.)
 
-def test_MeanFunction_from_formula():
+def test_MeanFunction():
     "test the function to create a mean function from a formula"
 
-    mf = MeanFunction.from_formula(None)
+    mf = MeanFunction(None)
 
     assert isinstance(mf, ConstantMean)
     assert_allclose(mf.mean_f(np.ones((2,3)), np.zeros(0)), np.zeros((2)))
 
-    mf2 = MeanFunction.from_formula("x[0]", use_patsy=True)
+    mf2 = MeanFunction("x[0]", use_patsy=True)
 
     assert isinstance(mf2, MeanSum)
     assert_allclose(mf2.mean_f(np.array([[1., 2., 3.], [4., 5., 6.]]), np.array([1., 2.])),
                     np.array([3., 9.]))
 
-    mf3 = MeanFunction.from_formula("a + b*c", {"c":0}, use_patsy=False)
+    mf3 = MeanFunction("a + b*c", {"c":0}, use_patsy=False)
 
     assert isinstance(mf3, MeanSum)
     assert_allclose(mf3.mean_f(np.array([[1., 2., 3.], [4., 5., 6.]]), np.array([1., 2.])),
                     np.array([3., 9.]))
 
     with pytest.raises(ValueError):
-        MeanFunction.from_formula(1)
+        MeanFunction(1)
 
 def test_fixed_functions(x):
     "test utility functions for creating fixed means"

--- a/mogp_emulator/tests/test_formula.py
+++ b/mogp_emulator/tests/test_formula.py
@@ -59,6 +59,14 @@ def test_mean_from_patsy_formula(code, inputdict, params, resulttype, result):
 @pytest.mark.parametrize("code,inputdict,params,resulttype,result",
                          [("x[0]",
                            {}     , np.zeros(0)       , LinearMean , np.array([1., 4.])),
+                          ("y = x[0]",
+                           {}     , np.zeros(0)       , LinearMean , np.array([1., 4.])),
+                          ("y ~ x[0]",
+                           {}     , np.zeros(0)       , LinearMean , np.array([1., 4.])),
+                          ("~ x[0]",
+                           {}     , np.zeros(0)       , LinearMean , np.array([1., 4.])),
+                          ("= x[0]",
+                           {}     , np.zeros(0)       , LinearMean , np.array([1., 4.])),
                           ("a",
                            {}     , np.ones(1)        , Coefficient, np.array([1., 1.])),
                           ("a",
@@ -183,6 +191,10 @@ def test_inputstr_to_mean_failures():
         inputstr_to_mean("x[-19]")
 
 @pytest.mark.parametrize("code,result", [("a", ["a"]),
+                                         ("y = a", ["a"]),
+                                         ("y ~ a", ["a"]),
+                                         ("= a", ["a"]),
+                                         ("~ a", ["a"]),
                                          ("a + b", ["a", "+", "b"]),
                                          ("a*b+ c", ["a", "*", "b", "+", "c"]),
                                          ("x[0]", ["x[0]"]),
@@ -218,6 +230,12 @@ def test_tokenize_string_failures():
     with pytest.raises(SyntaxError):
         tokenize_string("call")
 
+    with pytest.raises(SyntaxError):
+        tokenize_string("a + b = c")
+
+    with pytest.raises(SyntaxError):
+        tokenize_string("a + b ~ c")
+
 @pytest.mark.parametrize("token_list,output_list",
                          [(["a"], ["a"]),
                           (["a", "+", "b"], ["a", "b", "+"]),
@@ -245,6 +263,12 @@ def test_parse_tokens_failures():
 
     with pytest.raises(SyntaxError):
         parse_tokens(["x" "*", "a", "+", "b", ")"])
+
+    with pytest.raises(SyntaxError):
+        parse_tokens(["="])
+
+    with pytest.raises(SyntaxError):
+        parse_tokens(["~"])
 
 @pytest.mark.parametrize("stack,inputdict,params,resulttype,result",
                          [(["x[0]"],
@@ -295,3 +319,9 @@ def test_eval_parsed_tokens_failures():
 
     with pytest.raises(SyntaxError):
         eval_parsed_tokens(["a", "b"])
+
+    with pytest.raises(SyntaxError):
+        eval_parsed_tokens(["="])
+
+    with pytest.raises(SyntaxError):
+        eval_parsed_tokens(["~"])

--- a/mogp_emulator/tests/test_formula.py
+++ b/mogp_emulator/tests/test_formula.py
@@ -1,0 +1,109 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from ..formula import parse_factor_code, _is_float, inputstr_to_mean
+from ..MeanFunction import ConstantMean, Coefficient, LinearMean
+try:
+    no_patsy = False
+except ImportError:
+    no_patsy = True
+
+patsy_skip = pytest.mark.skipif(no_patsy, reason="patsy is needed to test formula parsing")
+
+@patsy_skip
+def test_mean_from_patsy_formula():
+    pass
+
+@patsy_skip
+def test_mean_from_patsy_formula_failures():
+    pass
+
+@patsy_skip
+def test_term_to_mean():
+    pass
+
+@patsy_skip
+def test_term_to_mean_failures():
+    pass
+
+def test_code_to_mean():
+    pass
+
+def test_code_to_mean_failures():
+    pass
+
+@pytest.mark.parametrize("code,inputdict,result", [("x[1]", {}, "x[1]"),
+                                                   ("inputs[0]", {}, "x[0]"),
+                                                   ("a", {}, "a"),
+                                                   ("a", {"a":0}, "x[0]"),
+                                                   ("d", {"d":1}, "x[1]")])
+def test_parse_factor_code(code, inputdict, result):
+    "test the function to parse factor code"
+
+    assert parse_factor_code(code, inputdict) == result
+
+def test_parse_factor_code_failures():
+    "test situations where parse_factor_code should fail"
+
+    with pytest.raises(AssertionError):
+        parse_factor_code(1)
+
+def test_is_float():
+    "test the _is_float function"
+
+    assert _is_float("1")
+    assert _is_float("-2.e-4")
+    assert not _is_float("a")
+
+@pytest.mark.parametrize("code,inputdict,params,resulttype,result",
+                         [("2."  , {}     , np.zeros(0), ConstantMean, np.array([2., 2.])),
+                          ("a"   , {}     , np.ones(1) , Coefficient , np.array([1., 1.])),
+                          ("x[0]", {}     , np.zeros(0), LinearMean  , np.array([1., 4.])),
+                          ("a"   , {"a":0}, np.zeros(0), LinearMean  , np.array([1., 4.]))])
+def test_inputstr_to_mean(code, inputdict, params, resulttype, result):
+    "test the inputstr_to_mean function"
+
+    x = np.array([[1., 2., 3.], [4., 5., 6.]])
+
+    mf = inputstr_to_mean(code, inputdict)
+
+    assert isinstance(mf, resulttype)
+    assert mf.get_n_params(x) == len(params)
+
+    assert_allclose(mf.mean_f(x, params), result)
+
+def test_inputstr_to_mean_failures():
+    "test situation where inputstr_to_mean should fail"
+
+    with pytest.raises(AssertionError):
+        inputstr_to_mean(1)
+
+    with pytest.raises(ValueError):
+        inputstr_to_mean("x[0")
+
+    with pytest.raises(ValueError):
+        inputstr_to_mean("x(1]")
+
+    with pytest.raises(ValueError):
+        inputstr_to_mean("x[a]")
+
+    with pytest.raises(AssertionError):
+        inputstr_to_mean("x[-19]")
+
+def test_tokenize_string():
+    pass
+
+def test_tokenize_string_failures():
+    pass
+
+def test_parse_tokens():
+    pass
+
+def test_parse_tokens_failures():
+    pass
+
+def test_eval_parsed_tokens():
+    pass
+
+def test_eval_parsed_tokens_failures():
+    pass

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 0
+PRERELEASE = 2
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Implements string formula parsing for specifying mean functions. New `formula` module added, along with some modifications to the `MeanFunction` module. Addresses Issue #8.

* `formula` module, which contains a number of functions for converting strings into mean functions. This parsing can be done with `patsy` package, which is designed to handle R-style formulas for specifying regression models, though the module is able to parse strings without `patsy` so this is not a required dependency
* `MeanFunction`"factory" function for creating a mean function from a string. This required re-naming the previous base mean class as `MeanBase` (since this class was never directly accessed by the user, I feel this approach is a bit cleaner and avoids the issue of whether or not to make the factory function a class method or a static method).
* A full suite of unit tests for all new functionality
* Documentation pages for the formula module
