### PR TITLE
Fix/powermeanderiv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 3
+PRERELEASE = 4
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Fixes a few bugs in the computation of derivatives in the `PowerMean` class. The derivative and Hessian computations weren't correct in all cases, and in a few cases a computation that was not needed ended up raising an exception that was nor applicable. These have been fixed, and I added a few unit tests to check for these conditions. Fixes issue #82.

* Corrections to the `PowerMean` class to correct the `mean_deriv` and `mean_hessian` methods for a few cases.
* Unit tests to catch these situations and ensure correct behavior.