### PR TITLE
Fix/absoluteimports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "3.7"
 install:
   - pip install -r requirements.txt
-  - pip install pytest-cov codecov patsy
+  - pip install -r requirements-dev.txt
+  - pip install -r requirements-optional.txt
   - python setup.py install
 script:
   - pytest --cov=./

--- a/mogp_emulator/DimensionReduction.py
+++ b/mogp_emulator/DimensionReduction.py
@@ -70,7 +70,7 @@ regression on the reduced input space:
 import sys
 import numpy as np
 from scipy.spatial.distance import cdist, pdist, squareform
-from .utils import k_fold_cross_validation, integer_bisect
+from mogp_emulator.utils import k_fold_cross_validation, integer_bisect
 
 def gram_matrix(X, k):
     """Computes the Gram matrix of `X`

--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -1,10 +1,10 @@
 import numpy as np
-from .MeanFunction import MeanFunction, MeanBase
-from .Kernel import Kernel, SquaredExponential
-from .Priors import Prior
+from mogp_emulator.MeanFunction import MeanFunction, MeanBase
+from mogp_emulator.Kernel import Kernel, SquaredExponential
+from mogp_emulator.Priors import Prior
 from scipy import linalg
 from scipy.optimize import OptimizeResult
-from .linalg.cholesky import jit_cholesky
+from mogp_emulator.linalg.cholesky import jit_cholesky
 
 class GaussianProcess(object):
     """

--- a/mogp_emulator/HistoryMatching.py
+++ b/mogp_emulator/HistoryMatching.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .GaussianProcess import GaussianProcess, PredictResult
+from mogp_emulator.GaussianProcess import GaussianProcess, PredictResult
 
 class HistoryMatching(object):
     r"""

--- a/mogp_emulator/MeanFunction.py
+++ b/mogp_emulator/MeanFunction.py
@@ -75,7 +75,7 @@ Example: ::
 import numpy as np
 from functools import partial
 from inspect import signature
-from .formula import mean_from_patsy_formula, mean_from_string
+from mogp_emulator.formula import mean_from_patsy_formula, mean_from_string
 
 def MeanFunction(formula, inputdict={}, use_patsy=True):
     """

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -1,9 +1,9 @@
 from multiprocessing import Pool
 import numpy as np
-from .GaussianProcess import GaussianProcess, PredictResult
-from .MeanFunction import MeanBase
-from .Kernel import Kernel, SquaredExponential
-from .Priors import Prior
+from mogp_emulator.GaussianProcess import GaussianProcess, PredictResult
+from mogp_emulator.MeanFunction import MeanBase
+from mogp_emulator.Kernel import Kernel, SquaredExponential
+from mogp_emulator.Priors import Prior
 
 class MultiOutputGP(object):
     """

--- a/mogp_emulator/SequentialDesign.py
+++ b/mogp_emulator/SequentialDesign.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy.spatial.distance import cdist
 from inspect import signature
-from .ExperimentalDesign import ExperimentalDesign
-from .GaussianProcess import GaussianProcess
-from .fitting import fit_GP_MAP
+from mogp_emulator.ExperimentalDesign import ExperimentalDesign
+from mogp_emulator.GaussianProcess import GaussianProcess
+from mogp_emulator.fitting import fit_GP_MAP
 from numpy.linalg import LinAlgError
 
 class SequentialDesign(object):

--- a/mogp_emulator/fitting.py
+++ b/mogp_emulator/fitting.py
@@ -2,8 +2,8 @@ import numpy as np
 import scipy.stats
 from scipy.linalg import LinAlgError
 from scipy.optimize import minimize
-from .GaussianProcess import GaussianProcess
-from .MultiOutputGP import MultiOutputGP
+from mogp_emulator.GaussianProcess import GaussianProcess
+from mogp_emulator.MultiOutputGP import MultiOutputGP
 from multiprocessing import Pool
 from functools import partial
 

--- a/mogp_emulator/formula.py
+++ b/mogp_emulator/formula.py
@@ -1,4 +1,4 @@
-from . import MeanFunction
+from mogp_emulator import MeanFunction
 try:
     from patsy import ModelDesc, Term, EvalFactor
     no_patsy = False

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 6
+PRERELEASE = 7
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Fixes a few issues with installation and building the html documentation. Addresses #94 and #97.

* Fixed issue with importing the module (`linalg` subpackage was missing an `__init__.py` file)
* Corrects `.travis.yml` to use the requirements files for installation
* Switch to absolute rather than relative imports as that is preferred (tests still use relative imports)