### PR TITLE
Fix/windows mogp

### DIFF
--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -1,4 +1,5 @@
 from multiprocessing import Pool
+import platform
 import numpy as np
 from mogp_emulator.GaussianProcess import GaussianProcess, PredictResult
 from mogp_emulator.MeanFunction import MeanBase
@@ -137,8 +138,11 @@ class MultiOutputGP(object):
             processes = int(processes)
             assert processes > 0, "number of processes must be a positive integer"
 
-        with Pool(processes) as p:
-            predict_vals = p.starmap(GaussianProcess.predict, [(gp, testing, unc, deriv) for gp in self.emulators])
+        if platform.system() == "Windows":
+            predict_vals = [GaussianProcess.predict(gp, testing, unc, deriv) for gp in self.emulators]
+        else:
+            with Pool(processes) as p:
+                predict_vals = p.starmap(GaussianProcess.predict, [(gp, testing, unc, deriv) for gp in self.emulators])
 
         # repackage predictions into numpy arrays
 

--- a/mogp_emulator/fitting.py
+++ b/mogp_emulator/fitting.py
@@ -6,6 +6,7 @@ from mogp_emulator.GaussianProcess import GaussianProcess
 from mogp_emulator.MultiOutputGP import MultiOutputGP
 from multiprocessing import Pool
 from functools import partial
+import platform
 
 def fit_GP_MAP(*args, n_tries=15, theta0=None, method="L-BFGS-B", **kwargs):
     """
@@ -165,9 +166,13 @@ def _fit_MOGP_MAP(gp, n_tries=15, theta0=None, method='L-BFGS-B', **kwargs):
 
     n_tries = int(n_tries)
 
-    with Pool(processes) as p:
-        fit_MOGP = p.starmap(partial(fit_GP_MAP, n_tries=n_tries, theta0=theta0, method=method, **kwargs),
-                            [(emulator,) for emulator in gp.emulators])
+    if platform.system() == "Windows":
+        fit_MOGP = [fit_GP_MAP(emulator, n_tries=n_tries, theta0=theta0, method=method, **kwargs)
+                    for emulator in gp.emulators]
+    else:
+        with Pool(processes) as p:
+            fit_MOGP = p.starmap(partial(fit_GP_MAP, n_tries=n_tries, theta0=theta0, method=method, **kwargs),
+                                 [(emulator,) for emulator in gp.emulators])
 
     gp.emulators = fit_MOGP
 

--- a/mogp_emulator/tests/test_fitting.py
+++ b/mogp_emulator/tests/test_fitting.py
@@ -71,13 +71,13 @@ def test_fit_GP_MAP_MOGP():
 
     theta_exp = np.zeros((2, 3))
     theta_exp[0] = np.array([ 1.6030532031342832, -2.090511425471982 , -0.7803960307137198])
-    theta_exp[1] = np.array([ 1.2807839212942222, -0.5095550757153631, -2.009987161484929 ])
+    theta_exp[1] = np.array([ 1.414112951818647 , -0.5974688573393576,  0.6857536842773265])
     logpost_exp = np.zeros(2)
     logpost_exp[0] = -296.0297245831661
-    logpost_exp[1] = -249.82550942156362
+    logpost_exp[1] = -250.06025683867367
     np.random.seed(4335)
 
-    gp = fit_GP_MAP(gp)
+    gp = fit_GP_MAP(gp, processes=1)
 
     assert isinstance(gp, MultiOutputGP)
     for i in range(2):
@@ -88,7 +88,7 @@ def test_fit_GP_MAP_MOGP():
 
     np.random.seed(4335)
 
-    gp = fit_GP_MAP(x, y, mean="0.", use_patsy=False, method="L-BFGS-B")
+    gp = fit_GP_MAP(x, y, mean="0.", use_patsy=False, method="L-BFGS-B", processes=1)
     assert isinstance(gp, MultiOutputGP)
     for i in range(2):
         assert_allclose(gp.emulators[i].theta, theta_exp[i])
@@ -176,13 +176,13 @@ def test_fit_MOGP_MAP_MOGP():
 
     theta_exp = np.zeros((2, 3))
     theta_exp[0] = np.array([ 1.6030532031342832, -2.090511425471982 , -0.7803960307137198])
-    theta_exp[1] = np.array([ 1.2807839212942222, -0.5095550757153631, -2.009987161484929 ])
+    theta_exp[1] = np.array([ 1.414112951818647 , -0.5974688573393576,  0.6857536842773265])
     logpost_exp = np.zeros(2)
     logpost_exp[0] = -296.0297245831661
-    logpost_exp[1] = -249.82550942156362
+    logpost_exp[1] = -250.06025683867367
     np.random.seed(4335)
 
-    gp = _fit_MOGP_MAP(gp)
+    gp = _fit_MOGP_MAP(gp, processes=1)
 
     assert isinstance(gp, MultiOutputGP)
     for i in range(2):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 9
+PRERELEASE = 10
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Fixes an issue with multiprocessing on Windows machines by forcing a single thread on Windows. Will try to investigate more thoroughly if I can access an appropriate VM (or borrow a machine). May or may not be temporary.

Changes:

* Modification to `MultiOutputGP` and fitting routine to detect windows and force a single thread for those cases.
* Tests using multiple outputs were failing on a single thread, so modified tests to use one thread for consistency.