### PR TITLE
Fix/predictnugget

### DIFF
--- a/mogp_emulator/tests/test_GaussianProcess.py
+++ b/mogp_emulator/tests/test_GaussianProcess.py
@@ -470,6 +470,30 @@ def test_GaussianProcess_predict(x, y, dx):
 
     assert_allclose(gp(x_test), mu_expect)
 
+def test_GaussianProcess_predict_nugget(x, y):
+    "test that the nugget works correctly when making predictions"
+
+    nugget = 1.e0
+
+    gp = GaussianProcess(x, y, nugget=nugget)
+    theta = np.ones(gp.n_params)
+
+    gp.fit(theta)
+
+    preds = gp.predict(x)
+
+    K = gp.kernel.kernel_f(x, x, theta[:-1])
+
+    var_expect = np.exp(theta[-2]) + nugget - np.diag(np.dot(K, np.linalg.solve(K + np.eye(gp.n)*nugget, K)))
+
+    assert_allclose(preds.unc, var_expect, atol=1.e-7)
+
+    preds = gp.predict(x, include_nugget=False)
+
+    var_expect = np.exp(theta[-2]) - np.diag(np.dot(K, np.linalg.solve(K + np.eye(gp.n)*nugget, K)))
+
+    assert_allclose(preds.unc, var_expect, atol=1.e-7)
+
 def test_GaussianProcess_predict_variance():
     "confirm that caching factorized matrix produces stable variance predictions"
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 12
+PRERELEASE = 13
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Fixes a problem with ambiguity around whether or not predictions include the nugget. See issue #119 for more details -- short version is that we assume the predictive variance should include the nugget by default, but give the user the option to turn it off if desired. Note that this will potentially change the prediction behavior compared to previous versions.

Changes in this PR:
* Modified ``GaussianProcess.predict`` to add an ``include_nugget`` flag to control how the nugget is added to predictions.
* Similar modification to the ``MultiOutputGP.predict`` method to be consistent with the base GP class.
* Minor changes and corrections to documentation
* Unit tests for GP and MOGP classes to explicitly confirm inclusion/exclusion of nugget