### PR TITLE
fix/test fitting

### DIFF
--- a/mogp_emulator/tests/test_fitting.py
+++ b/mogp_emulator/tests/test_fitting.py
@@ -146,7 +146,7 @@ def test_fit_GP_MAP_MOGP():
         fit_GP_MAP(gp, theta0=[None, None, None])
 
     with pytest.raises(AssertionError):
-        fit_GP_MAP(gp, theta0=[np.zeros(3), np.zeros(1)])
+        fit_GP_MAP(gp, theta0=[np.zeros(1), np.zeros(3)], processes=1)
 
 def test_fit_single_GP_MAP():
     "test the method to run the minimization algorithm on a GP class"
@@ -261,7 +261,7 @@ def test_fit_MOGP_MAP_MOGP():
         _fit_MOGP_MAP(gp, theta0=[None, None, None])
 
     with pytest.raises(AssertionError):
-        _fit_MOGP_MAP(gp, theta0=[None, np.zeros(1)])
+        _fit_MOGP_MAP(gp, theta0=[np.zeros(1), None], processes=1)
 
     with pytest.raises(AssertionError):
         _fit_MOGP_MAP(gp, processes=-1)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 15
+PRERELEASE = 16
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
This PR fixes a minor issue in mogp fitting tests where tests did not fail correctly. It only happens occasionally so I didn't catch it until running tests to merge devel into master in a separate PR. I am fixing it here on devel, but then I will propagate it through to the master update.

Changes:
* Minor fix in `test_fitting` for one of the multiple output tests that did not fail reliably in the correct way. Changed to a single process and put the failure case first to ensure that it does fail as planned.