### PR TITLE
reset version number to start work on next release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import setuptools
 
 # version information
 MAJOR = 0
-MINOR = 3
+MINOR = 4
 MICRO = 0
-PRERELEASE = 16
+PRERELEASE = 0
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
This PR resets the version number on devel to `v0.4.0dev0` to begin work on the next release.