### PR TITLE
Fix/kerneldist

### DIFF
--- a/mogp_emulator/Kernel.py
+++ b/mogp_emulator/Kernel.py
@@ -147,6 +147,9 @@ class Kernel(object):
 
         r_matrix = cdist(x1, x2, "seuclidean", V = exp_theta)
 
+        if np.any(np.isnan(r_matrix)):
+            raise FloatingPointError("NaN enountered in kernel distance computation")
+
         return r_matrix
 
     def calc_drdtheta(self, x1, x2, params):

--- a/mogp_emulator/tests/test_Kernel.py
+++ b/mogp_emulator/tests/test_Kernel.py
@@ -81,6 +81,9 @@ def test_calc_r_failures():
     with pytest.raises(AssertionError):
         k.calc_r(x, y, params)
 
+    with pytest.raises(FloatingPointError):
+        k.calc_r(y, y, np.array([800., 0.]))
+
 def test_calc_drdtheta():
     "test calc_drdtheta function"
 

--- a/mogp_emulator/tests/test_fitting.py
+++ b/mogp_emulator/tests/test_fitting.py
@@ -44,6 +44,9 @@ def test_fit_GP_MAP():
     with pytest.raises(RuntimeError):
         fit_GP_MAP(gp, n_tries=1)
 
+    with pytest.raises(RuntimeError):
+        fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+
     # bad inputs
 
     with pytest.raises(TypeError):
@@ -119,6 +122,9 @@ def test_fit_GP_MAP_MOGP():
     with pytest.raises(RuntimeError):
         fit_GP_MAP(gp, n_tries=1)
 
+    with pytest.raises(RuntimeError):
+        fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+
     # bad inputs
 
     with pytest.raises(TypeError):
@@ -175,6 +181,9 @@ def test_fit_single_GP_MAP():
 
     with pytest.raises(RuntimeError):
         _fit_single_GP_MAP(gp, n_tries=1)
+
+    with pytest.raises(RuntimeError):
+        _fit_single_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
 
     # bad inputs
 
@@ -236,6 +245,9 @@ def test_fit_MOGP_MAP_MOGP():
 
     with pytest.raises(RuntimeError):
         _fit_MOGP_MAP(gp, n_tries=1)
+
+    with pytest.raises(RuntimeError):
+        _fit_MOGP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
 
     # bad inputs
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 # version information
 MAJOR = 0
 MINOR = 3
-MICRO = 0
+MICRO = 1
 PRERELEASE = 0
 ISRELEASED = True
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)


### PR DESCRIPTION
Fixes a bug that occasionally crept up when fitting emulators, addressing issue #128.

Changes in this PR:

* Modified the kernel distance metric computation to correctly raise a `FloatingPointError` in the event of detecting a NaN in the distance array. This can happen when there is an underflow in converting the raw hyperparameters from the log to linear scale.
* Unit tests to confirm raising of this error, as well as a fitting test that starting at such a point leads to an error.